### PR TITLE
NN-3779: Add handover deadline time to incident details

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/DraftAdjudicationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/DraftAdjudicationDto.kt
@@ -26,6 +26,8 @@ data class IncidentDetailsDto(
   val locationId: Long,
   @ApiModelProperty(value = "Date and time the incident occurred", example = "2010-10-12T10:00:00")
   val dateTimeOfIncident: LocalDateTime,
+  @ApiModelProperty(value = "When this report must be handed to the prisoner", example = "2010-10-14T10:00:00")
+  val handoverDeadline: LocalDateTime,
   @ApiModelProperty("Created by user id")
   val createdByUserId: String? = null,
   @ApiModelProperty("Created on date time")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/IncidentDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/IncidentDetails.kt
@@ -10,4 +10,5 @@ class IncidentDetails(
   override val id: Long? = null,
   var locationId: Long,
   var dateTimeOfIncident: LocalDateTime,
+  var handoverDeadline: LocalDateTime,
 ) : BaseEntity()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/ReportedAdjudication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/ReportedAdjudication.kt
@@ -22,7 +22,8 @@ data class ReportedAdjudication(
       dateTimeReportExpires = dateTimeReportExpires,
       incidentDetails = IncidentDetailsDto(
         locationId = incidentLocationId,
-        dateTimeOfIncident = incidentTime
+        dateTimeOfIncident = incidentTime,
+        handoverDeadline = dateTimeReportExpires
       ),
       incidentStatement = IncidentStatementDto(
         statement = statement

--- a/src/main/resources/db/migration/V6__add_handover_deadline_column_to_incident_details.sql
+++ b/src/main/resources/db/migration/V6__add_handover_deadline_column_to_incident_details.sql
@@ -1,0 +1,1 @@
+alter table incident_details add column handover_deadline timestamp   null;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/DraftAdjudicationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/DraftAdjudicationControllerTest.kt
@@ -37,7 +37,11 @@ class DraftAdjudicationControllerTest : TestControllerBase() {
         DraftAdjudicationDto(
           id = 1,
           prisonerNumber = "A12345",
-          incidentDetails = IncidentDetailsDto(locationId = 2, dateTimeOfIncident = DATE_TIME_OF_INCIDENT)
+          incidentDetails = IncidentDetailsDto(
+            locationId = 2,
+            dateTimeOfIncident = DATE_TIME_OF_INCIDENT,
+            handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
+          )
         )
       )
     }
@@ -65,6 +69,7 @@ class DraftAdjudicationControllerTest : TestControllerBase() {
         .andExpect(jsonPath("draftAdjudication.prisonerNumber").value("A12345"))
         .andExpect(jsonPath("draftAdjudication.incidentDetails.locationId").value(2))
         .andExpect(jsonPath("draftAdjudication.incidentDetails.dateTimeOfIncident").value("2010-10-12T10:00:00"))
+        .andExpect(jsonPath("draftAdjudication.incidentDetails.handoverDeadline").value("2010-10-14T10:00:00"))
     }
 
     @Test
@@ -119,7 +124,11 @@ class DraftAdjudicationControllerTest : TestControllerBase() {
         DraftAdjudicationDto(
           id = 1,
           prisonerNumber = "A12345",
-          incidentDetails = IncidentDetailsDto(locationId = 1L, dateTimeOfIncident = DATE_TIME_OF_INCIDENT)
+          incidentDetails = IncidentDetailsDto(
+            locationId = 1L,
+            dateTimeOfIncident = DATE_TIME_OF_INCIDENT,
+            handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
+          )
         )
       )
       makeGetDraftAdjudicationRequest(1)
@@ -127,6 +136,7 @@ class DraftAdjudicationControllerTest : TestControllerBase() {
         .andExpect(jsonPath("$.draftAdjudication.id").isNumber)
         .andExpect(jsonPath("$.draftAdjudication.prisonerNumber").value("A12345"))
         .andExpect(jsonPath("$.draftAdjudication.incidentDetails.dateTimeOfIncident").value("2010-10-12T10:00:00"))
+        .andExpect(jsonPath("$.draftAdjudication.incidentDetails.handoverDeadline").value("2010-10-14T10:00:00"))
         .andExpect(jsonPath("$.draftAdjudication.incidentDetails.locationId").value(1))
     }
 
@@ -155,7 +165,7 @@ class DraftAdjudicationControllerTest : TestControllerBase() {
         DraftAdjudicationDto(
           id = 1L,
           prisonerNumber = "A12345",
-          incidentDetails = IncidentDetailsDto(locationId = 1, DATE_TIME_OF_INCIDENT),
+          incidentDetails = IncidentDetailsDto(locationId = 1, DATE_TIME_OF_INCIDENT, DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE),
           incidentStatement = IncidentStatementDto(statement = "test")
         )
       )
@@ -216,7 +226,7 @@ class DraftAdjudicationControllerTest : TestControllerBase() {
         DraftAdjudicationDto(
           id = 1L,
           prisonerNumber = "A12345",
-          incidentDetails = IncidentDetailsDto(locationId = 3, DATE_TIME_OF_INCIDENT)
+          incidentDetails = IncidentDetailsDto(locationId = 3, DATE_TIME_OF_INCIDENT, DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE)
         )
       )
     }
@@ -245,6 +255,7 @@ class DraftAdjudicationControllerTest : TestControllerBase() {
         .andExpect(jsonPath("$.draftAdjudication.prisonerNumber").value("A12345"))
         .andExpect(jsonPath("$.draftAdjudication.incidentDetails.locationId").value(3))
         .andExpect(jsonPath("$.draftAdjudication.incidentDetails.dateTimeOfIncident").value("2010-10-12T10:00:00"))
+        .andExpect(jsonPath("$.draftAdjudication.incidentDetails.handoverDeadline").value("2010-10-14T10:00:00"))
     }
 
     @Test
@@ -282,7 +293,7 @@ class DraftAdjudicationControllerTest : TestControllerBase() {
         DraftAdjudicationDto(
           id = 1L,
           prisonerNumber = "A12345",
-          incidentDetails = IncidentDetailsDto(locationId = 1, DATE_TIME_OF_INCIDENT),
+          incidentDetails = IncidentDetailsDto(locationId = 1, DATE_TIME_OF_INCIDENT, DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE),
           incidentStatement = IncidentStatementDto(statement = "new statement")
         )
       )
@@ -357,12 +368,20 @@ class DraftAdjudicationControllerTest : TestControllerBase() {
           DraftAdjudicationDto(
             id = 1,
             prisonerNumber = "A12345",
-            incidentDetails = IncidentDetailsDto(locationId = 1, dateTimeOfIncident = DATE_TIME_OF_INCIDENT)
+            incidentDetails = IncidentDetailsDto(
+              locationId = 1,
+              dateTimeOfIncident = DATE_TIME_OF_INCIDENT,
+              handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
+            )
           ),
           DraftAdjudicationDto(
             id = 2,
             prisonerNumber = "A12346",
-            incidentDetails = IncidentDetailsDto(locationId = 2, dateTimeOfIncident = DATE_TIME_OF_INCIDENT.plusMonths(1))
+            incidentDetails = IncidentDetailsDto(
+              locationId = 2,
+              dateTimeOfIncident = DATE_TIME_OF_INCIDENT.plusMonths(1),
+              handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE.plusMonths(1)
+            )
           )
         )
       )
@@ -392,10 +411,12 @@ class DraftAdjudicationControllerTest : TestControllerBase() {
         .andExpect(jsonPath("$.draftAdjudications[0].prisonerNumber").value("A12345"))
         .andExpect(jsonPath("$.draftAdjudications[0].incidentDetails.locationId").value(1))
         .andExpect(jsonPath("$.draftAdjudications[0].incidentDetails.dateTimeOfIncident").value("2010-10-12T10:00:00"))
+        .andExpect(jsonPath("$.draftAdjudications[0].incidentDetails.handoverDeadline").value("2010-10-14T10:00:00"))
         .andExpect(jsonPath("$.draftAdjudications[1].id").value(2))
         .andExpect(jsonPath("$.draftAdjudications[1].prisonerNumber").value("A12346"))
         .andExpect(jsonPath("$.draftAdjudications[1].incidentDetails.locationId").value(2))
         .andExpect(jsonPath("$.draftAdjudications[1].incidentDetails.dateTimeOfIncident").value("2010-11-12T10:00:00"))
+        .andExpect(jsonPath("$.draftAdjudications[0].incidentDetails.handoverDeadline").value("2010-10-14T10:00:00"))
     }
 
     fun getInProgressDraftAdjudications(): ResultActions = mockMvc
@@ -407,5 +428,6 @@ class DraftAdjudicationControllerTest : TestControllerBase() {
 
   companion object {
     private val DATE_TIME_OF_INCIDENT = LocalDateTime.of(2010, 10, 12, 10, 0, 0)
+    private val DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE = LocalDateTime.of(2010, 10, 14, 10, 0)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/ReportedAdjudicationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/ReportedAdjudicationControllerTest.kt
@@ -48,7 +48,11 @@ class ReportedAdjudicationControllerTest : TestControllerBase() {
           prisonerNumber = "A12345",
           bookingId = 123,
           dateTimeReportExpires = DATE_TIME_OF_INCIDENT.plusDays(2),
-          incidentDetails = IncidentDetailsDto(locationId = 2, dateTimeOfIncident = DATE_TIME_OF_INCIDENT),
+          incidentDetails = IncidentDetailsDto(
+            locationId = 2,
+            dateTimeOfIncident = DATE_TIME_OF_INCIDENT,
+            handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
+          ),
           incidentStatement = IncidentStatementDto(statement = INCIDENT_STATEMENT)
         )
       )
@@ -59,6 +63,7 @@ class ReportedAdjudicationControllerTest : TestControllerBase() {
         .andExpect(jsonPath("$.reportedAdjudication.bookingId").value("123"))
         .andExpect(jsonPath("$.reportedAdjudication.dateTimeReportExpires").value("2010-10-14T10:00:00"))
         .andExpect(jsonPath("$.reportedAdjudication.incidentDetails.dateTimeOfIncident").value("2010-10-12T10:00:00"))
+        .andExpect(jsonPath("$.reportedAdjudication.incidentDetails.handoverDeadline").value("2010-10-14T10:00:00"))
         .andExpect(jsonPath("$.reportedAdjudication.incidentDetails.locationId").value(2))
         .andExpect(jsonPath("$.reportedAdjudication.incidentStatement.statement").value(INCIDENT_STATEMENT))
     }
@@ -94,7 +99,11 @@ class ReportedAdjudicationControllerTest : TestControllerBase() {
               prisonerNumber = "A12345",
               bookingId = 123,
               dateTimeReportExpires = DATE_TIME_OF_INCIDENT.plusDays(2),
-              incidentDetails = IncidentDetailsDto(locationId = 2, dateTimeOfIncident = DATE_TIME_OF_INCIDENT),
+              incidentDetails = IncidentDetailsDto(
+                locationId = 2,
+                dateTimeOfIncident = DATE_TIME_OF_INCIDENT,
+                handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
+              ),
               incidentStatement = IncidentStatementDto(statement = INCIDENT_STATEMENT)
             )
           ),
@@ -138,6 +147,9 @@ class ReportedAdjudicationControllerTest : TestControllerBase() {
         .andExpect(
           jsonPath("$.content[0].incidentDetails.dateTimeOfIncident").value("2010-10-12T10:00:00")
         )
+        .andExpect(
+          jsonPath("$.content[0].incidentDetails.handoverDeadline").value("2010-10-14T10:00:00")
+        )
         .andExpect(jsonPath("$.content[0].incidentDetails.locationId").value(2))
         .andExpect(
           jsonPath("$.content[0].incidentStatement.statement").value(
@@ -162,6 +174,7 @@ class ReportedAdjudicationControllerTest : TestControllerBase() {
 
   companion object {
     private val DATE_TIME_OF_INCIDENT = LocalDateTime.of(2010, 10, 12, 10, 0, 0)
+    private val DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE = LocalDateTime.of(2010, 10, 14, 10, 0)
     private const val INCIDENT_STATEMENT = "A statement"
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/DraftAdjudicationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/DraftAdjudicationIntTest.kt
@@ -27,11 +27,14 @@ class DraftAdjudicationIntTest : IntegrationTestBase() {
       .jsonPath("$.draftAdjudication.createdByUserId").isEqualTo("ITAG_USER")
       .jsonPath("$.draftAdjudication.createdDateTime").exists()
       .jsonPath("$.draftAdjudication.incidentDetails.dateTimeOfIncident").isEqualTo("2010-10-12T10:00:00")
+      .jsonPath("$.draftAdjudication.incidentDetails.handoverDeadline").isEqualTo("2010-10-14T10:00:00")
       .jsonPath("$.draftAdjudication.incidentDetails.locationId").isEqualTo(1)
   }
 
   @Test
   fun `get draft adjudication details`() {
+    bankHolidayApiMockServer.stubGetBankHolidays()
+
     val draftAdjudicationResponse = dataAPiHelpers().startNewAdjudication(dateTimeOfIncident = DATE_TIME_OF_INCIDENT)
 
     webTestClient.get()
@@ -45,11 +48,14 @@ class DraftAdjudicationIntTest : IntegrationTestBase() {
       .jsonPath("$.draftAdjudication.createdByUserId").isEqualTo("ITAG_USER")
       .jsonPath("$.draftAdjudication.createdDateTime").exists()
       .jsonPath("$.draftAdjudication.incidentDetails.dateTimeOfIncident").isEqualTo("2010-10-12T10:00:00")
+      .jsonPath("$.draftAdjudication.incidentDetails.handoverDeadline").isEqualTo("2010-10-14T10:00:00")
       .jsonPath("$.draftAdjudication.incidentDetails.locationId").isEqualTo(2)
   }
 
   @Test
   fun `add the incident statement to the draft adjudication`() {
+    bankHolidayApiMockServer.stubGetBankHolidays()
+
     val draftAdjudicationResponse = dataAPiHelpers().startNewAdjudication(dateTimeOfIncident = DATE_TIME_OF_INCIDENT)
 
     webTestClient.post()
@@ -65,6 +71,7 @@ class DraftAdjudicationIntTest : IntegrationTestBase() {
       .expectBody()
       .jsonPath("$.draftAdjudication.id").isNumber
       .jsonPath("$.draftAdjudication.incidentDetails.dateTimeOfIncident").isEqualTo("2010-10-12T10:00:00")
+      .jsonPath("$.draftAdjudication.incidentDetails.handoverDeadline").isEqualTo("2010-10-14T10:00:00")
       .jsonPath("$.draftAdjudication.incidentDetails.locationId").isEqualTo(2)
       .jsonPath("$.draftAdjudication.prisonerNumber").isEqualTo("A12345")
       .jsonPath("$.draftAdjudication.incidentStatement.statement").isEqualTo("test")
@@ -76,6 +83,8 @@ class DraftAdjudicationIntTest : IntegrationTestBase() {
 
   @Test
   fun `edit the incident details`() {
+    bankHolidayApiMockServer.stubGetBankHolidays()
+
     val draftAdjudicationResponse = dataAPiHelpers().startNewAdjudication(dateTimeOfIncident = DATE_TIME_OF_INCIDENT)
 
     webTestClient.put()
@@ -93,6 +102,7 @@ class DraftAdjudicationIntTest : IntegrationTestBase() {
       .jsonPath("$.draftAdjudication.id").isNumber
       .jsonPath("$.draftAdjudication.prisonerNumber").isEqualTo("A12345")
       .jsonPath("$.draftAdjudication.incidentDetails.dateTimeOfIncident").isEqualTo("2010-11-12T10:00:00")
+      .jsonPath("$.draftAdjudication.incidentDetails.handoverDeadline").isEqualTo("2010-11-15T10:00:00")
       .jsonPath("$.draftAdjudication.incidentDetails.locationId").isEqualTo(3)
       .jsonPath("$.draftAdjudication.incidentDetails.modifiedByUserId").isEqualTo("ITAG_USER")
       .jsonPath("$.draftAdjudication.incidentDetails.modifiedByDateTime").exists()
@@ -102,6 +112,8 @@ class DraftAdjudicationIntTest : IntegrationTestBase() {
 
   @Test
   fun `edit the incident statement`() {
+    bankHolidayApiMockServer.stubGetBankHolidays()
+
     val draftAdjudicationResponse = dataAPiHelpers().startNewAdjudication(dateTimeOfIncident = DATE_TIME_OF_INCIDENT)
 
     dataAPiHelpers().addIncidentStatement(draftAdjudicationResponse.draftAdjudication.id, "test statement")
@@ -146,6 +158,7 @@ class DraftAdjudicationIntTest : IntegrationTestBase() {
       .jsonPath("$.dateTimeReportExpires").isEqualTo("2010-11-15T10:00:00")
       .jsonPath("$.incidentStatement.statement").isEqualTo("new statement")
       .jsonPath("$.incidentDetails.dateTimeOfIncident").isEqualTo("2010-11-12T10:00:00")
+      .jsonPath("$.incidentDetails.handoverDeadline").isEqualTo("2010-11-15T10:00:00")
       .jsonPath("$.incidentDetails.locationId").isEqualTo(721850)
 
     val expectedBody = mapOf(
@@ -190,6 +203,7 @@ class DraftAdjudicationIntTest : IntegrationTestBase() {
       .jsonPath("$.draftAdjudications[0].id").isEqualTo(draftAdjudicationResponse.draftAdjudication.id)
       .jsonPath("$.draftAdjudications[0].prisonerNumber").isEqualTo("A12345")
       .jsonPath("$.draftAdjudications[0].incidentDetails.dateTimeOfIncident").isEqualTo("2010-10-12T10:00:00")
+      .jsonPath("$.draftAdjudications[0].incidentDetails.handoverDeadline").isEqualTo("2010-10-14T10:00:00")
       .jsonPath("$.draftAdjudications[0].incidentDetails.locationId").isEqualTo(2)
       .jsonPath("$.draftAdjudications[0].incidentDetails.modifiedByUserId").isEqualTo("ITAG_USER")
       .jsonPath("$.draftAdjudications[0].incidentDetails.modifiedByDateTime").exists()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/DraftAdjudicationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/DraftAdjudicationRepositoryTest.kt
@@ -33,7 +33,11 @@ class DraftAdjudicationRepositoryTest {
       DraftAdjudication(
         prisonerNumber = "A12345",
         agencyId = "MDI",
-        incidentDetails = IncidentDetails(locationId = 2, dateTimeOfIncident = dateTimeOfIncident)
+        incidentDetails = IncidentDetails(
+          locationId = 2,
+          dateTimeOfIncident = dateTimeOfIncident,
+          handoverDeadline = dateTimeOfIncident.plusDays(2)
+        )
       )
     )
     assertThat(savedEntity)
@@ -41,8 +45,8 @@ class DraftAdjudicationRepositoryTest {
       .contains(savedEntity.id, "A12345", "MDI", "ITAG_USER")
 
     assertThat(savedEntity.incidentDetails)
-      .extracting("locationId", "dateTimeOfIncident")
-      .contains(2L, dateTimeOfIncident)
+      .extracting("locationId", "dateTimeOfIncident", "handoverDeadline")
+      .contains(2L, dateTimeOfIncident, dateTimeOfIncident.plusDays(2))
   }
 
   @Test
@@ -53,14 +57,22 @@ class DraftAdjudicationRepositoryTest {
       DraftAdjudication(
         prisonerNumber = "A12345",
         agencyId = "MDI",
-        incidentDetails = IncidentDetails(locationId = 2, dateTimeOfIncident = dateTimeOfIncident)
+        incidentDetails = IncidentDetails(
+          locationId = 2,
+          dateTimeOfIncident = dateTimeOfIncident,
+          handoverDeadline = dateTimeOfIncident.plusDays(2)
+        )
       )
     )
     entityManager.persistAndFlush(
       DraftAdjudication(
         prisonerNumber = "A12346",
         agencyId = "LEI",
-        incidentDetails = IncidentDetails(locationId = 2, dateTimeOfIncident = dateTimeOfIncident)
+        incidentDetails = IncidentDetails(
+          locationId = 2,
+          dateTimeOfIncident = dateTimeOfIncident,
+          handoverDeadline = dateTimeOfIncident.plusDays(2)
+        )
       )
     )
     val foundAdjudications = draftAdjudicationRepository.findByAgencyIdAndCreatedByUserId("MDI", "ITAG_USER")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/DraftAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/DraftAdjudicationServiceTest.kt
@@ -61,9 +61,14 @@ class DraftAdjudicationServiceTest {
           id = 1,
           prisonerNumber = "A12345",
           agencyId = "MDI",
-          incidentDetails = IncidentDetails(locationId = 2, dateTimeOfIncident = DATE_TIME_OF_INCIDENT)
+          incidentDetails = IncidentDetails(
+            locationId = 2,
+            dateTimeOfIncident = DATE_TIME_OF_INCIDENT,
+            handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
+          )
         )
       )
+      whenever(dateCalculationService.calculate48WorkingHoursFrom(any())).thenReturn(DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE)
     }
 
     @Test
@@ -80,8 +85,8 @@ class DraftAdjudicationServiceTest {
         .contains(1L, "A12345")
 
       assertThat(draftAdjudication.incidentDetails)
-        .extracting("locationId", "dateTimeOfIncident")
-        .contains(2L, DATE_TIME_OF_INCIDENT)
+        .extracting("locationId", "dateTimeOfIncident", "handoverDeadline")
+        .contains(2L, DATE_TIME_OF_INCIDENT, DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE)
     }
   }
 
@@ -105,7 +110,11 @@ class DraftAdjudicationServiceTest {
           id = 1,
           prisonerNumber = "A12345",
           agencyId = "MDI",
-          incidentDetails = IncidentDetails(locationId = 2, dateTimeOfIncident = now)
+          incidentDetails = IncidentDetails(
+            locationId = 2,
+            dateTimeOfIncident = now,
+            handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
+          )
         )
 
       whenever(draftAdjudicationRepository.findById(any())).thenReturn(
@@ -142,7 +151,11 @@ class DraftAdjudicationServiceTest {
         id = 1,
         prisonerNumber = "A12345",
         agencyId = "MDI",
-        incidentDetails = IncidentDetails(locationId = 1, dateTimeOfIncident = LocalDateTime.now(clock)),
+        incidentDetails = IncidentDetails(
+          locationId = 1,
+          dateTimeOfIncident = LocalDateTime.now(clock),
+          handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
+        ),
       )
 
       whenever(draftAdjudicationRepository.findById(any())).thenReturn(Optional.of(draftAdjudicationEntity))
@@ -176,7 +189,11 @@ class DraftAdjudicationServiceTest {
               id = 1,
               prisonerNumber = "A12345",
               agencyId = "MDI",
-              incidentDetails = IncidentDetails(locationId = 1, dateTimeOfIncident = LocalDateTime.now(clock)),
+              incidentDetails = IncidentDetails(
+                locationId = 1,
+                dateTimeOfIncident = LocalDateTime.now(clock),
+                handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
+              ),
               incidentStatement = IncidentStatement(id = 1, statement = "test")
             )
           )
@@ -211,12 +228,19 @@ class DraftAdjudicationServiceTest {
 
     @Test
     fun `makes changes to the incident details`() {
+      whenever(dateCalculationService.calculate48WorkingHoursFrom(any())).thenReturn(DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE)
+
       val dateTimeOfIncident = DATE_TIME_OF_INCIDENT.plusMonths(1)
       val draftAdjudicationEntity = DraftAdjudication(
         id = 1,
         prisonerNumber = "A12345",
         agencyId = "MDI",
-        incidentDetails = IncidentDetails(id = 1, locationId = 2, dateTimeOfIncident = DATE_TIME_OF_INCIDENT)
+        incidentDetails = IncidentDetails(
+          id = 1,
+          locationId = 2,
+          dateTimeOfIncident = DATE_TIME_OF_INCIDENT,
+          handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
+        )
       )
 
       whenever(draftAdjudicationRepository.findById(any())).thenReturn(Optional.of(draftAdjudicationEntity))
@@ -225,7 +249,8 @@ class DraftAdjudicationServiceTest {
           incidentDetails = IncidentDetails(
             id = 1,
             locationId = 3L,
-            dateTimeOfIncident = dateTimeOfIncident
+            dateTimeOfIncident = dateTimeOfIncident,
+            handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
           )
         )
       )
@@ -237,8 +262,8 @@ class DraftAdjudicationServiceTest {
         .contains(1L, "A12345")
 
       assertThat(draftAdjudication.incidentDetails)
-        .extracting("locationId", "dateTimeOfIncident")
-        .contains(3L, dateTimeOfIncident)
+        .extracting("locationId", "dateTimeOfIncident", "handoverDeadline")
+        .contains(3L, dateTimeOfIncident, DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE)
 
       val argumentCaptor = ArgumentCaptor.forClass(DraftAdjudication::class.java)
       verify(draftAdjudicationRepository).save(argumentCaptor.capture())
@@ -277,7 +302,11 @@ class DraftAdjudicationServiceTest {
             id = 1,
             prisonerNumber = "A12345",
             agencyId = "MDI",
-            incidentDetails = IncidentDetails(locationId = 1, dateTimeOfIncident = LocalDateTime.now(clock)),
+            incidentDetails = IncidentDetails(
+              locationId = 1,
+              dateTimeOfIncident = LocalDateTime.now(clock),
+              handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
+            ),
           )
         )
       )
@@ -296,7 +325,11 @@ class DraftAdjudicationServiceTest {
           id = 1,
           prisonerNumber = "A12345",
           agencyId = "MDI",
-          incidentDetails = IncidentDetails(locationId = 1, dateTimeOfIncident = LocalDateTime.now(clock)),
+          incidentDetails = IncidentDetails(
+            locationId = 1,
+            dateTimeOfIncident = LocalDateTime.now(clock),
+            handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
+          ),
           incidentStatement = IncidentStatement(statement = "old statement")
         )
 
@@ -344,7 +377,11 @@ class DraftAdjudicationServiceTest {
           DraftAdjudication(
             prisonerNumber = "A12345",
             agencyId = "MDI",
-            incidentDetails = IncidentDetails(locationId = 1, dateTimeOfIncident = LocalDateTime.now())
+            incidentDetails = IncidentDetails(
+              locationId = 1,
+              dateTimeOfIncident = LocalDateTime.now(),
+              handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
+            )
           )
         )
       )
@@ -365,7 +402,11 @@ class DraftAdjudicationServiceTest {
               id = 1,
               prisonerNumber = "A12345",
               agencyId = "MDI",
-              incidentDetails = IncidentDetails(locationId = 1, dateTimeOfIncident = LocalDateTime.now(clock)),
+              incidentDetails = IncidentDetails(
+                locationId = 1,
+                dateTimeOfIncident = LocalDateTime.now(clock),
+                handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
+              ),
               incidentStatement = IncidentStatement(statement = "test")
             )
           )
@@ -437,14 +478,20 @@ class DraftAdjudicationServiceTest {
             incidentDetails = IncidentDetails(
               id = 2,
               locationId = 2,
-              dateTimeOfIncident = LocalDateTime.now(clock).plusMonths(2)
+              dateTimeOfIncident = LocalDateTime.now(clock).plusMonths(2),
+              handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
             )
           ),
           DraftAdjudication(
             id = 2,
             prisonerNumber = "A12346",
             agencyId = "MDI",
-            incidentDetails = IncidentDetails(id = 3, locationId = 3, dateTimeOfIncident = LocalDateTime.now(clock))
+            incidentDetails = IncidentDetails(
+              id = 3,
+              locationId = 3,
+              dateTimeOfIncident = LocalDateTime.now(clock),
+              handoverDeadline = DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE
+            )
           )
         )
       )
@@ -476,14 +523,15 @@ class DraftAdjudicationServiceTest {
       assertThat(adjudications)
         .extracting("id", "prisonerNumber", "incidentDetails")
         .contains(
-          Tuple(2L, "A12346", IncidentDetailsDto(3, LocalDateTime.now(clock))),
-          Tuple(1L, "A12345", IncidentDetailsDto(2, LocalDateTime.now(clock).plusMonths(2)))
+          Tuple(2L, "A12346", IncidentDetailsDto(3, LocalDateTime.now(clock), DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE)),
+          Tuple(1L, "A12345", IncidentDetailsDto(2, LocalDateTime.now(clock).plusMonths(2), DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE))
         )
     }
   }
 
   companion object {
     private val DATE_TIME_OF_INCIDENT = LocalDateTime.of(2010, 10, 12, 10, 0)
+    private val DATE_TIME_DRAFT_ADJUDICATION_HANDOVER_DEADLINE = LocalDateTime.of(2010, 10, 14, 10, 0)
     private val DATE_TIME_REPORTED_ADJUDICATION_EXPIRES = LocalDateTime.of(2010, 10, 14, 10, 0)
   }
 }


### PR DESCRIPTION
This is the same as the report expiry date - we need to refactor it to match, which we can do when we sort out the test data.