### PR TITLE
NN-3899: Save reported adjudications locally

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities
+
+import java.time.LocalDateTime
+import javax.persistence.Entity
+import javax.persistence.Table
+
+@Entity
+@Table(name = "reported_adjudications")
+data class ReportedAdjudication(
+  override val id: Long? = null,
+  var prisonerNumber: String,
+  var bookingId: Long,
+  var reportNumber: Long,
+  var agencyId: String,
+  var locationId: Long,
+  var dateTimeOfIncident: LocalDateTime,
+  var handoverDeadline: LocalDateTime,
+  var statement: String,
+) : BaseEntity()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisAdjudication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisAdjudication.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.IncidentSta
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.ReportedAdjudicationDto
 import java.time.LocalDateTime
 
-data class ReportedAdjudication(
+data class NomisAdjudication(
   val adjudicationNumber: Long,
   val reporterStaffId: Long,
   val offenderNo: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/PrisonApiGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/PrisonApiGateway.kt
@@ -6,36 +6,36 @@ import org.springframework.web.reactive.function.client.WebClient
 
 @Service
 class PrisonApiGateway(private val prisonApiClientCreds: WebClient) {
-  fun getReportedAdjudication(adjudicationNumber: Long): ReportedAdjudication = prisonApiClientCreds
+  fun getReportedAdjudication(adjudicationNumber: Long): NomisAdjudication = prisonApiClientCreds
     .get()
     .uri("/adjudications/adjudication/$adjudicationNumber")
     .retrieve()
-    .bodyToMono(object : ParameterizedTypeReference<ReportedAdjudication>() {})
+    .bodyToMono(object : ParameterizedTypeReference<NomisAdjudication>() {})
     .block()!!
 
-  fun publishAdjudication(adjudicationDetailsToPublish: AdjudicationDetailsToPublish): ReportedAdjudication =
+  fun publishAdjudication(adjudicationDetailsToPublish: AdjudicationDetailsToPublish): NomisAdjudication =
     prisonApiClientCreds
       .post()
       .uri("/adjudications/adjudication")
       .bodyValue(adjudicationDetailsToPublish)
       .retrieve()
-      .bodyToMono(object : ParameterizedTypeReference<ReportedAdjudication>() {})
+      .bodyToMono(object : ParameterizedTypeReference<NomisAdjudication>() {})
       .block()!!
 
-  fun updateAdjudication(adjudicationNumber: Long, adjudicationDetailsToUpdate: AdjudicationDetailsToUpdate): ReportedAdjudication =
+  fun updateAdjudication(adjudicationNumber: Long, adjudicationDetailsToUpdate: AdjudicationDetailsToUpdate): NomisAdjudication =
     prisonApiClientCreds
       .put()
       .uri("/adjudications/adjudication/$adjudicationNumber")
       .bodyValue(adjudicationDetailsToUpdate)
       .retrieve()
-      .bodyToMono(object : ParameterizedTypeReference<ReportedAdjudication>() {})
+      .bodyToMono(object : ParameterizedTypeReference<NomisAdjudication>() {})
       .block()!!
 
-  fun getReportedAdjudications(adjudicationNumbers: Collection<Long>): List<ReportedAdjudication> = prisonApiClientCreds
+  fun getReportedAdjudications(adjudicationNumbers: Collection<Long>): List<NomisAdjudication> = prisonApiClientCreds
     .post()
     .uri("/adjudications")
     .bodyValue(adjudicationNumbers)
     .retrieve()
-    .bodyToMono(object : ParameterizedTypeReference<List<ReportedAdjudication>>() {})
+    .bodyToMono(object : ParameterizedTypeReference<List<NomisAdjudication>>() {})
     .block()!!
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories
+
+import org.springframework.data.repository.CrudRepository
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudication
+
+interface ReportedAdjudicationRepository : CrudRepository<ReportedAdjudication, Long> {
+  fun findByReportNumber(adjudicationNumber: Long): ReportedAdjudication?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/DraftAdjudicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/DraftAdjudicationService.kt
@@ -12,8 +12,8 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Reporte
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.SubmittedAdjudicationHistory
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.AdjudicationDetailsToPublish
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.AdjudicationDetailsToUpdate
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonApiGateway
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.NomisAdjudication
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonApiGateway
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.DraftAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.SubmittedAdjudicationHistoryRepository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/DraftAdjudicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/DraftAdjudicationService.kt
@@ -8,12 +8,14 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.ReportedAdj
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.DraftAdjudication
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.IncidentDetails
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.IncidentStatement
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudication
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.SubmittedAdjudicationHistory
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.AdjudicationDetailsToPublish
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.AdjudicationDetailsToUpdate
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonApiGateway
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.ReportedAdjudication
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.NomisAdjudication
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.DraftAdjudicationRepository
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.SubmittedAdjudicationHistoryRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.AuthenticationFacade
 import java.time.Clock
@@ -24,6 +26,7 @@ import javax.transaction.Transactional
 @Service
 class DraftAdjudicationService(
   val draftAdjudicationRepository: DraftAdjudicationRepository,
+  val reportedAdjudicationRepository: ReportedAdjudicationRepository,
   val submittedAdjudicationHistoryRepository: SubmittedAdjudicationHistoryRepository,
   val prisonApiGateway: PrisonApiGateway,
   val dateCalculationService: DateCalculationService,
@@ -108,17 +111,18 @@ class DraftAdjudicationService(
   fun completeDraftAdjudication(id: Long): ReportedAdjudicationDto {
     val draftAdjudication = draftAdjudicationRepository.findById(id).orElseThrow { throwEntityNotFoundException(id) }
 
-    if (draftAdjudication.incidentStatement == null)
+    if (draftAdjudication.incidentStatement == null || draftAdjudication.incidentStatement!!.statement == null)
       throw IllegalStateException("Please include an incident statement before completing this draft adjudication")
 
     val isNew = draftAdjudication.reportNumber == null
-    val reportedAdjudication = saveToPrisonApi(draftAdjudication, isNew)
-    saveToSubmittedReports(reportedAdjudication, isNew)
+    val nomisAdjudication = saveToPrisonApi(draftAdjudication, isNew)
+    saveToSubmittedReports(nomisAdjudication, isNew)
+    saveToReportedAdjudications(draftAdjudication, nomisAdjudication, isNew)
 
     draftAdjudicationRepository.delete(draftAdjudication)
 
-    return reportedAdjudication
-      .toDto(dateCalculationService.calculate48WorkingHoursFrom(reportedAdjudication.incidentTime))
+    return nomisAdjudication
+      .toDto(dateCalculationService.calculate48WorkingHoursFrom(nomisAdjudication.incidentTime))
   }
 
   fun getCurrentUsersInProgressDraftAdjudications(agencyId: String): List<DraftAdjudicationDto> {
@@ -129,7 +133,7 @@ class DraftAdjudicationService(
       .map { it.toDto() }
   }
 
-  private fun saveToPrisonApi(draftAdjudication: DraftAdjudication, isNew: Boolean): ReportedAdjudication {
+  private fun saveToPrisonApi(draftAdjudication: DraftAdjudication, isNew: Boolean): NomisAdjudication {
     if (isNew) {
       return prisonApiGateway.publishAdjudication(
         AdjudicationDetailsToPublish(
@@ -152,22 +156,56 @@ class DraftAdjudicationService(
     }
   }
 
-  private fun saveToSubmittedReports(reportedAdjudication: ReportedAdjudication, isNew: Boolean) {
+  private fun saveToSubmittedReports(nomisAdjudication: NomisAdjudication, isNew: Boolean) {
     if (isNew) {
       submittedAdjudicationHistoryRepository.save(
         SubmittedAdjudicationHistory(
-          adjudicationNumber = reportedAdjudication.adjudicationNumber,
-          agencyId = reportedAdjudication.agencyId,
-          dateTimeOfIncident = reportedAdjudication.incidentTime,
+          adjudicationNumber = nomisAdjudication.adjudicationNumber,
+          agencyId = nomisAdjudication.agencyId,
+          dateTimeOfIncident = nomisAdjudication.incidentTime,
           LocalDateTime.now(clock)
         )
       )
     } else {
-      val previousSubmittedAdjudicationHistory = submittedAdjudicationHistoryRepository.findByAdjudicationNumber(reportedAdjudication.adjudicationNumber)
+      val previousSubmittedAdjudicationHistory = submittedAdjudicationHistoryRepository.findByAdjudicationNumber(nomisAdjudication.adjudicationNumber)
       previousSubmittedAdjudicationHistory?.let {
-        it.dateTimeOfIncident = reportedAdjudication.incidentTime
+        it.dateTimeOfIncident = nomisAdjudication.incidentTime
         it.dateTimeSent = LocalDateTime.now(clock)
-        submittedAdjudicationHistoryRepository.save(previousSubmittedAdjudicationHistory)
+        submittedAdjudicationHistoryRepository.save(it)
+      }
+    }
+  }
+
+  private fun saveToReportedAdjudications(
+    draftAdjudication: DraftAdjudication,
+    nomisAdjudication: NomisAdjudication,
+    isNew: Boolean
+  ) {
+    if (isNew) {
+      reportedAdjudicationRepository.save(
+        ReportedAdjudication(
+          bookingId = nomisAdjudication.bookingId,
+          reportNumber = nomisAdjudication.adjudicationNumber,
+          prisonerNumber = draftAdjudication.prisonerNumber,
+          agencyId = draftAdjudication.agencyId,
+          locationId = draftAdjudication.incidentDetails.locationId,
+          dateTimeOfIncident = draftAdjudication.incidentDetails.dateTimeOfIncident,
+          handoverDeadline = draftAdjudication.incidentDetails.handoverDeadline,
+          statement = draftAdjudication.incidentStatement!!.statement!!
+        )
+      )
+    } else {
+      val previousReportedAdjudication = reportedAdjudicationRepository.findByReportNumber(nomisAdjudication.adjudicationNumber)
+      previousReportedAdjudication?.let {
+        it.bookingId = nomisAdjudication.bookingId
+        it.reportNumber = nomisAdjudication.adjudicationNumber
+        it.prisonerNumber = draftAdjudication.prisonerNumber
+        it.agencyId = draftAdjudication.agencyId
+        it.locationId = draftAdjudication.incidentDetails.locationId
+        it.dateTimeOfIncident = draftAdjudication.incidentDetails.dateTimeOfIncident
+        it.handoverDeadline = draftAdjudication.incidentDetails.handoverDeadline
+        it.statement = draftAdjudication.incidentStatement!!.statement!!
+        reportedAdjudicationRepository.save(it)
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/ReportedAdjudicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/ReportedAdjudicationService.kt
@@ -9,8 +9,8 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.DraftAd
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.IncidentDetails
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.IncidentStatement
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.SubmittedAdjudicationHistory
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonApiGateway
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.NomisAdjudication
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonApiGateway
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.DraftAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.SubmittedAdjudicationHistoryRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.AuthenticationFacade

--- a/src/main/resources/db/migration/V11__create_reported_adjudication_table.sql
+++ b/src/main/resources/db/migration/V11__create_reported_adjudication_table.sql
@@ -1,0 +1,19 @@
+drop table if exists reported_adjudications;
+
+create table reported_adjudications
+(
+    id                          serial primary key,
+    prisoner_number             varchar(7)  not null,
+    booking_id                  bigint      not null,
+    report_number               bigint      not null,
+    agency_id                   varchar(6)  not null,
+    date_time_of_incident       timestamp   not null,
+    handover_deadline           timestamp   not null,
+    location_id                 bigint      not null,
+    statement                   varchar     not null,
+    create_user_id              varchar(32) not null,
+    create_datetime             timestamp   not null,
+    modify_user_id              varchar(32),
+    modify_datetime             timestamp,
+    constraint unique_report_number UNIQUE (report_number)
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepositoryTest.kt
@@ -9,8 +9,6 @@ import org.springframework.context.annotation.Import
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.config.AuditConfiguration
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.DraftAdjudication
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.IncidentDetails
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudication
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.UserDetails
 import java.time.LocalDateTime

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepositoryTest.kt
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories
+
+import org.assertj.core.api.Java6Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.context.annotation.Import
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.config.AuditConfiguration
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.DraftAdjudication
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.IncidentDetails
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudication
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.UserDetails
+import java.time.LocalDateTime
+
+@DataJpaTest
+@ActiveProfiles("test")
+@WithMockUser(username = "ITAG_USER")
+@Import(AuditConfiguration::class, UserDetails::class)
+class ReportedAdjudicationRepositoryTest {
+  @Autowired
+  lateinit var entityManager: TestEntityManager
+
+  @Autowired
+  lateinit var reportedAdjudicationRepository: ReportedAdjudicationRepository
+
+  @Test
+  fun `find reported adjudications by report number`() {
+    val dateTimeOfIncident = LocalDateTime.now()
+
+    entityManager.persistAndFlush(
+      ReportedAdjudication(
+        prisonerNumber = "A12345",
+        reportNumber = 1234L,
+        bookingId = 44L,
+        agencyId = "MDI",
+        locationId = 2,
+        dateTimeOfIncident = dateTimeOfIncident,
+        handoverDeadline = dateTimeOfIncident.plusDays(2),
+        statement = "Example"
+      )
+    )
+    entityManager.persistAndFlush(
+      ReportedAdjudication(
+        prisonerNumber = "A12345",
+        reportNumber = 1235L,
+        bookingId = 44L,
+        agencyId = "MDI",
+        locationId = 3,
+        dateTimeOfIncident = dateTimeOfIncident.plusHours(1),
+        handoverDeadline = dateTimeOfIncident.plusHours(1).plusDays(2),
+        statement = "Example 2"
+      )
+    )
+    val foundAdjudication = reportedAdjudicationRepository.findByReportNumber(1234L)
+
+    assertThat(foundAdjudication)
+      .extracting("reportNumber", "statement")
+      .contains(
+        1234L, "Example"
+      )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/DraftAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/DraftAdjudicationServiceTest.kt
@@ -19,8 +19,8 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Reporte
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.SubmittedAdjudicationHistory
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.AdjudicationDetailsToPublish
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.AdjudicationDetailsToUpdate
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonApiGateway
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.NomisAdjudication
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonApiGateway
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.DraftAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.SubmittedAdjudicationHistoryRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/ReportedAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/ReportedAdjudicationServiceTest.kt
@@ -16,8 +16,8 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.DraftAd
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.IncidentDetails
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.IncidentStatement
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.SubmittedAdjudicationHistory
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonApiGateway
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.NomisAdjudication
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonApiGateway
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.DraftAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.SubmittedAdjudicationHistoryRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.AuthenticationFacade

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/ReportedAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/ReportedAdjudicationServiceTest.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Inciden
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.IncidentStatement
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.SubmittedAdjudicationHistory
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonApiGateway
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.ReportedAdjudication
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.NomisAdjudication
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.DraftAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.SubmittedAdjudicationHistoryRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.AuthenticationFacade
@@ -41,7 +41,7 @@ class ReportedAdjudicationServiceTest {
   }
 
   @Nested
-  inner class ReportedAdjudicationDetails {
+  inner class NomisAdjudicationDetails {
     @Test
     fun `throws an entity not found if the reported adjudication for the supplied id does not exists`() {
       whenever(prisonApiGateway.getReportedAdjudication(any())).thenThrow(EntityNotFoundException("ReportedAdjudication not found for 1"))
@@ -55,7 +55,7 @@ class ReportedAdjudicationServiceTest {
     @Test
     fun `returns the reported adjudication`() {
       val reportedAdjudication =
-        ReportedAdjudication(
+        NomisAdjudication(
           adjudicationNumber = 1, offenderNo = "AA1234A", bookingId = 123, reporterStaffId = 234, agencyId = "MDI",
           incidentTime = DATE_TIME_OF_INCIDENT, incidentLocationId = 345, statement = INCIDENT_STATEMENT,
           createdByUserId = "A_SMITH",
@@ -79,7 +79,7 @@ class ReportedAdjudicationServiceTest {
   }
 
   @Nested
-  inner class AllReportedAdjudications {
+  inner class AllNomisAdjudications {
     @BeforeEach
     fun beforeEach() {
       whenever(submittedAdjudicationHistoryRepository.findByAgencyId(any(), any())).thenReturn(
@@ -92,12 +92,12 @@ class ReportedAdjudicationServiceTest {
       )
       whenever(prisonApiGateway.getReportedAdjudications(any())).thenReturn(
         listOf(
-          ReportedAdjudication(
+          NomisAdjudication(
             adjudicationNumber = 1, offenderNo = "AA1234A", bookingId = 123, reporterStaffId = 234, agencyId = "MDI",
             incidentTime = DATE_TIME_OF_INCIDENT, incidentLocationId = 345, statement = INCIDENT_STATEMENT,
             createdByUserId = "A_SMITH",
           ),
-          ReportedAdjudication(
+          NomisAdjudication(
             adjudicationNumber = 2, offenderNo = "AA1234B", bookingId = 456, reporterStaffId = 234, agencyId = "MDI",
             incidentTime = DATE_TIME_OF_INCIDENT, incidentLocationId = 345, statement = INCIDENT_STATEMENT,
             createdByUserId = "A_SMITH",
@@ -135,7 +135,7 @@ class ReportedAdjudicationServiceTest {
   }
 
   @Nested
-  inner class MyReportedAdjudications {
+  inner class MyNomisAdjudications {
     @BeforeEach
     fun beforeEach() {
       whenever(submittedAdjudicationHistoryRepository.findByCreatedByUserIdAndAgencyId(any(), any(), any())).thenReturn(
@@ -148,12 +148,12 @@ class ReportedAdjudicationServiceTest {
       )
       whenever(prisonApiGateway.getReportedAdjudications(any())).thenReturn(
         listOf(
-          ReportedAdjudication(
+          NomisAdjudication(
             adjudicationNumber = 1, offenderNo = "AA1234A", bookingId = 123, reporterStaffId = 234, agencyId = "MDI",
             incidentTime = DATE_TIME_OF_INCIDENT, incidentLocationId = 345, statement = INCIDENT_STATEMENT,
             createdByUserId = "A_SMITH",
           ),
-          ReportedAdjudication(
+          NomisAdjudication(
             adjudicationNumber = 2, offenderNo = "AA1234B", bookingId = 456, reporterStaffId = 234, agencyId = "MDI",
             incidentTime = DATE_TIME_OF_INCIDENT, incidentLocationId = 345, statement = INCIDENT_STATEMENT,
             createdByUserId = "A_SMITH",
@@ -185,7 +185,7 @@ class ReportedAdjudicationServiceTest {
 
   @Nested
   inner class CreateDraftFromReported {
-    val reportedAdjudication = ReportedAdjudication(
+    val reportedAdjudication = NomisAdjudication(
       adjudicationNumber = 123, offenderNo = "AA1234A", bookingId = 123, reporterStaffId = 234, agencyId = "MDI",
       incidentTime = DATE_TIME_OF_INCIDENT, incidentLocationId = 345, statement = INCIDENT_STATEMENT,
       createdByUserId = "A_SMITH",


### PR DESCRIPTION
It might look daunting, but all the logic changes are in 1 method: DraftAdjudicationService.completeDraft.. The rest of the changes are an enforced renaming of an existing class

It now saves the data in a new Reported.. table as well as the existing Submitted.. table.