### PR TITLE
NN-4678 issued endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/ReportedAdjudicationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/ReportedAdjudicationDto.kt
@@ -46,6 +46,10 @@ data class ReportedAdjudicationDto(
   val witnesses: List<ReportedWitnessDto>,
   @Schema(description = "Hearings related to adjudication")
   val hearings: List<HearingDto>,
+  @Schema(description = "issuing officer")
+  val issuingOfficer: String? = null,
+  @Schema(description = "date time of form issued")
+  val dateTimeOfIssue: LocalDateTime? = null,
 )
 
 @Schema(description = "Details of an offence")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
@@ -57,6 +57,8 @@ data class ReportedAdjudication(
   @JoinColumn(name = "reported_adjudication_fk_id")
   var hearings: MutableList<Hearing>,
   var draftCreatedOn: LocalDateTime,
+  var issuingOfficer: String? = null,
+  var dateTimeOfIssue: LocalDateTime? = null,
 ) :
   BaseEntity() {
   fun transition(to: ReportedAdjudicationStatus, reason: String? = null, details: String? = null, reviewUserId: String? = null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -58,6 +58,8 @@ open class ReportedDtoService(
     statusReason = statusReason,
     statusDetails = statusDetails,
     hearings = toHearings(hearings),
+    issuingOfficer = issuingOfficer,
+    dateTimeOfIssue = dateTimeOfIssue,
   )
 
   private fun toReportedOffence(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonA
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.OffenceCodeLookupService
+import java.time.LocalDateTime
 import javax.persistence.EntityNotFoundException
 import javax.transaction.Transactional
 import javax.validation.ValidationException
@@ -61,6 +62,15 @@ class ReportedAdjudicationService(
     )
 
     return reportedAdjudicationToReturn
+  }
+
+  fun setIssued(adjudicationNumber: Long, dateTimeOfIssue: LocalDateTime): ReportedAdjudicationDto {
+    val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber)
+
+    reportedAdjudication.issuingOfficer = authenticationFacade.currentUsername
+    reportedAdjudication.dateTimeOfIssue = dateTimeOfIssue
+
+    return saveToDto(reportedAdjudication)
   }
 
   private fun saveToPrisonApi(reportedAdjudication: ReportedAdjudication) {

--- a/src/main/resources/db/migration/V45__issued_details.sql
+++ b/src/main/resources/db/migration/V45__issued_details.sql
@@ -1,0 +1,2 @@
+ALTER TABLE reported_adjudications ADD COLUMN issuing_officer varchar(32);
+ALTER TABLE reported_adjudications ADD COLUMN date_time_of_issue timestamp;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReportedAdjudicationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReportedAdjudicationIntTest.kt
@@ -927,6 +927,41 @@ class ReportedAdjudicationIntTest : IntegrationTestBase() {
       .isEqualTo(reportedAdjudication.reportedAdjudication.hearings.first().oicHearingType.name)
   }
 
+  @Test
+  fun `set issued details for DIS form `() {
+    val intTestData = integrationTestData()
+
+    val draftUserHeaders = setHeaders(username = IntegrationTestData.DEFAULT_ADJUDICATION.createdByUserId)
+    val draftIntTestScenarioBuilder = IntegrationTestScenarioBuilder(intTestData, this, draftUserHeaders)
+
+    draftIntTestScenarioBuilder
+      .startDraft(IntegrationTestData.DEFAULT_ADJUDICATION)
+      .setApplicableRules()
+      .setIncidentRole()
+      .setOffenceData()
+      .addIncidentStatement()
+      .addDamages()
+      .addEvidence()
+      .addWitnesses()
+      .completeDraft()
+
+    val dateTimeOfIssue = LocalDateTime.of(2022, 11, 29, 10, 0)
+
+    webTestClient.put()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/issue")
+      .headers(setHeaders())
+      .bodyValue(
+        mapOf(
+          "dateTimeOfIssue" to dateTimeOfIssue
+        )
+      )
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.issuingOfficer").isEqualTo("ITAG_USER")
+      .jsonPath("$.reportedAdjudication.dateTimeOfIssue").isEqualTo("2022-11-29T10:00:00")
+  }
+
   private fun initMyReportData() {
     val intTestData = integrationTestData()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepositoryTest.kt
@@ -299,4 +299,18 @@ class ReportedAdjudicationRepositoryTest {
 
     assertThat(hearings.size).isEqualTo(2)
   }
+
+  @Test
+  fun `set issue details `() {
+    val adjudication = reportedAdjudicationRepository.findByReportNumber(1236L)
+    val now = LocalDateTime.now()
+    adjudication!!.issuingOfficer = "testing"
+    adjudication!!.dateTimeOfIssue = now
+
+    val savedEntity = reportedAdjudicationRepository.save(adjudication)
+
+    assertThat(savedEntity)
+      .extracting("issuingOfficer", "dateTimeOfIssue")
+      .contains("testing", now)
+  }
 }


### PR DESCRIPTION
note, as per A/C only the user who actually issued the DIS physically can issue it via DPS, so the username is captured via authFacade.