### PR TITLE
NN-4695 issued filters

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/ReportsController.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.ReportedAdjudicationDto
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.IssuedStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.ReportsService
 import java.time.LocalDate
@@ -150,6 +151,11 @@ class ReportsController(
       required = false,
       description = "optional inclusive end date for results, default is today"
     ),
+    Parameter(
+      name = "issueStatus",
+      required = false,
+      description = "optional list of issue status, as comma separated String"
+    ),
   )
   @GetMapping("/agency/{agencyId}/issue")
   fun getReportedAdjudicationsForIssue(
@@ -157,6 +163,7 @@ class ReportsController(
     @RequestParam(name = "locationId") locationId: Long?,
     @RequestParam(name = "startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate?,
     @RequestParam(name = "endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate?,
+    @RequestParam(name = "issueStatus") issueStatuses: List<IssuedStatus>?,
     @PageableDefault(sort = ["dateTimeOfDiscovery"], direction = Sort.Direction.ASC, size = 20) pageable: Pageable
   ): Page<ReportedAdjudicationDto> {
 
@@ -165,6 +172,7 @@ class ReportsController(
       locationId = locationId,
       startDate = startDate ?: LocalDate.now().minusDays(2),
       endDate = endDate ?: LocalDate.now(),
+      issueStatuses = issueStatuses,
       pageable = pageable,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/ReportsController.kt
@@ -14,8 +14,8 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.ReportedAdjudicationDto
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.IssuedStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.IssuedStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.ReportsService
 import java.time.LocalDate
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
@@ -113,6 +113,14 @@ enum class ReportedAdjudicationStatus {
   }
 
   fun canBeIssuedValidation() {
-    if (listOf(SCHEDULED, UNSCHEDULED).none { it == this }) throw ValidationException("$this not valid status for DIS issue")
+    if (issuableStatuses().none { it == this }) throw ValidationException("$this not valid status for DIS issue")
   }
+
+  companion object {
+    fun issuableStatuses() = listOf(SCHEDULED, UNSCHEDULED)
+  }
+}
+
+enum class IssuedStatus {
+  ISSUED, NOT_ISSUED
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
@@ -120,7 +120,3 @@ enum class ReportedAdjudicationStatus {
     fun issuableStatuses() = listOf(SCHEDULED, UNSCHEDULED)
   }
 }
-
-enum class IssuedStatus {
-  ISSUED, NOT_ISSUED
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepository.kt
@@ -23,9 +23,39 @@ interface ReportedAdjudicationRepository : CrudRepository<ReportedAdjudication, 
     statuses: List<ReportedAdjudicationStatus>,
     pageable: Pageable
   ): Page<ReportedAdjudication>
+  fun findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndDateTimeOfIssueIsNotNull(
+    agencyId: String,
+    startDate: LocalDateTime,
+    endDate: LocalDateTime,
+    statuses: List<ReportedAdjudicationStatus>,
+    pageable: Pageable
+  ): Page<ReportedAdjudication>
+  fun findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndDateTimeOfIssueIsNull(
+    agencyId: String,
+    startDate: LocalDateTime,
+    endDate: LocalDateTime,
+    statuses: List<ReportedAdjudicationStatus>,
+    pageable: Pageable
+  ): Page<ReportedAdjudication>
   fun findByReportNumber(adjudicationNumber: Long): ReportedAdjudication?
   fun findByReportNumberIn(adjudicationNumbers: List<Long>): List<ReportedAdjudication>
   fun findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationId(
+    agencyId: String,
+    startDate: LocalDateTime,
+    endDate: LocalDateTime,
+    statuses: List<ReportedAdjudicationStatus>,
+    locationId: Long,
+    pageable: Pageable
+  ): Page<ReportedAdjudication>
+  fun findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationIdAndDateTimeOfIssueIsNotNull(
+    agencyId: String,
+    startDate: LocalDateTime,
+    endDate: LocalDateTime,
+    statuses: List<ReportedAdjudicationStatus>,
+    locationId: Long,
+    pageable: Pageable
+  ): Page<ReportedAdjudication>
+  fun findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationIdAndDateTimeOfIssueIsNull(
     agencyId: String,
     startDate: LocalDateTime,
     endDate: LocalDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportsService.kt
@@ -5,7 +5,6 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.ReportedAdjudicationDto
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.IssuedStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.AuthenticationFacade
@@ -13,6 +12,10 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.Offence
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+
+enum class IssuedStatus {
+  ISSUED, NOT_ISSUED
+}
 
 @Transactional(readOnly = true)
 @Service
@@ -61,14 +64,30 @@ class ReportsService(
 
   private fun getAdjudicationsForIssueAllLocations(agencyId: String, startDate: LocalDate, endDate: LocalDate, issueStatuses: List<IssuedStatus>, pageable: Pageable): Page<ReportedAdjudicationDto> {
     if (issueStatuses.containsAll(IssuedStatus.values().toList()))
-      return getAllReportedAdjudications(agencyId = agencyId, startDate = startDate, endDate = endDate, statuses = ReportedAdjudicationStatus.issuableStatuses(), pageable = pageable)
+      return getAllReportedAdjudications(
+        agencyId = agencyId,
+        startDate = startDate,
+        endDate = endDate,
+        statuses = ReportedAdjudicationStatus.issuableStatuses(),
+        pageable = pageable
+      )
+
     if (issueStatuses.contains(IssuedStatus.ISSUED))
       return reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndDateTimeOfIssueIsNotNull(
-        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), pageable = pageable
+        agencyId = agencyId,
+        startDate = reportsFrom(startDate),
+        endDate = reportsTo(endDate),
+        statuses = ReportedAdjudicationStatus.issuableStatuses(),
+        pageable = pageable
       ).map { it.toDto() }
+
     if (issueStatuses.contains(IssuedStatus.NOT_ISSUED))
       return reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndDateTimeOfIssueIsNull(
-        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), pageable = pageable
+        agencyId = agencyId,
+        startDate = reportsFrom(startDate),
+        endDate = reportsTo(endDate),
+        statuses = ReportedAdjudicationStatus.issuableStatuses(),
+        pageable = pageable
       ).map { it.toDto() }
 
     return Page.empty()
@@ -77,15 +96,32 @@ class ReportsService(
   private fun getAdjudicationsForIssueOneLocation(agencyId: String, locationId: Long, startDate: LocalDate, endDate: LocalDate, issueStatuses: List<IssuedStatus>, pageable: Pageable): Page<ReportedAdjudicationDto> {
     if (issueStatuses.containsAll(IssuedStatus.values().toList()))
       return reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationId(
-        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), locationId = locationId, pageable = pageable
+        agencyId = agencyId,
+        startDate = reportsFrom(startDate),
+        endDate = reportsTo(endDate),
+        statuses = ReportedAdjudicationStatus.issuableStatuses(),
+        locationId = locationId,
+        pageable = pageable
       ).map { it.toDto() }
+
     if (issueStatuses.contains(IssuedStatus.ISSUED))
       return reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationIdAndDateTimeOfIssueIsNotNull(
-        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), locationId = locationId, pageable = pageable
+        agencyId = agencyId,
+        startDate = reportsFrom(startDate),
+        endDate = reportsTo(endDate),
+        statuses = ReportedAdjudicationStatus.issuableStatuses(),
+        locationId = locationId,
+        pageable = pageable
       ).map { it.toDto() }
+
     if (issueStatuses.contains(IssuedStatus.NOT_ISSUED))
       return reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationIdAndDateTimeOfIssueIsNull(
-        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), locationId = locationId, pageable = pageable
+        agencyId = agencyId,
+        startDate = reportsFrom(startDate),
+        endDate = reportsTo(endDate),
+        statuses = ReportedAdjudicationStatus.issuableStatuses(),
+        locationId = locationId,
+        pageable = pageable
       ).map { it.toDto() }
 
     return Page.empty()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportsService.kt
@@ -74,18 +74,18 @@ class ReportsService(
     return Page.empty()
   }
 
-  private fun getAdjudicationsForIssueOneLocation(agencyId: String, locationId: Long? = null, startDate: LocalDate, endDate: LocalDate, issueStatuses: List<IssuedStatus>, pageable: Pageable): Page<ReportedAdjudicationDto> {
+  private fun getAdjudicationsForIssueOneLocation(agencyId: String, locationId: Long, startDate: LocalDate, endDate: LocalDate, issueStatuses: List<IssuedStatus>, pageable: Pageable): Page<ReportedAdjudicationDto> {
     if (issueStatuses.containsAll(IssuedStatus.values().toList()))
       return reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationId(
-        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), locationId = locationId!!, pageable = pageable
+        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), locationId = locationId, pageable = pageable
       ).map { it.toDto() }
     if (issueStatuses.contains(IssuedStatus.ISSUED))
       return reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationIdAndDateTimeOfIssueIsNotNull(
-        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), locationId = locationId!!, pageable = pageable
+        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), locationId = locationId, pageable = pageable
       ).map { it.toDto() }
     if (issueStatuses.contains(IssuedStatus.NOT_ISSUED))
       return reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationIdAndDateTimeOfIssueIsNull(
-        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), locationId = locationId!!, pageable = pageable
+        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), locationId = locationId, pageable = pageable
       ).map { it.toDto() }
 
     return Page.empty()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportsService.kt
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.ReportedAdjudicationDto
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.IssuedStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.AuthenticationFacade
@@ -44,14 +45,50 @@ class ReportsService(
     return reportedAdjudicationsPage.map { it.toDto() }
   }
 
-  fun getAdjudicationsForIssue(agencyId: String, locationId: Long? = null, startDate: LocalDate, endDate: LocalDate, pageable: Pageable): Page<ReportedAdjudicationDto> {
-    val statuses = listOf(ReportedAdjudicationStatus.SCHEDULED, ReportedAdjudicationStatus.UNSCHEDULED)
-    if (locationId == null)
-      return getAllReportedAdjudications(agencyId = agencyId, startDate = startDate, endDate = endDate, statuses = statuses, pageable = pageable)
+  fun getAdjudicationsForIssue(agencyId: String, locationId: Long? = null, startDate: LocalDate, endDate: LocalDate, issueStatuses: List<IssuedStatus>? = null, pageable: Pageable): Page<ReportedAdjudicationDto> {
 
-    return reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationId(
-      agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = statuses, locationId = locationId, pageable = pageable
-    ).map { it.toDto() }
+    val issueStatusesFilter = issueStatuses ?: IssuedStatus.values().toList()
+
+    if (locationId == null)
+      return getAdjudicationsForIssueAllLocations(
+        agencyId = agencyId, startDate = startDate, endDate = endDate, issueStatuses = issueStatusesFilter, pageable = pageable
+      )
+
+    return getAdjudicationsForIssueOneLocation(
+      agencyId = agencyId, locationId = locationId, startDate = startDate, endDate = endDate, issueStatuses = issueStatusesFilter, pageable = pageable
+    )
+  }
+
+  private fun getAdjudicationsForIssueAllLocations(agencyId: String, startDate: LocalDate, endDate: LocalDate, issueStatuses: List<IssuedStatus>, pageable: Pageable): Page<ReportedAdjudicationDto> {
+    if (issueStatuses.containsAll(IssuedStatus.values().toList()))
+      return getAllReportedAdjudications(agencyId = agencyId, startDate = startDate, endDate = endDate, statuses = ReportedAdjudicationStatus.issuableStatuses(), pageable = pageable)
+    if (issueStatuses.contains(IssuedStatus.ISSUED))
+      return reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndDateTimeOfIssueIsNotNull(
+        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), pageable = pageable
+      ).map { it.toDto() }
+    if (issueStatuses.contains(IssuedStatus.NOT_ISSUED))
+      return reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndDateTimeOfIssueIsNull(
+        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), pageable = pageable
+      ).map { it.toDto() }
+
+    return Page.empty()
+  }
+
+  private fun getAdjudicationsForIssueOneLocation(agencyId: String, locationId: Long? = null, startDate: LocalDate, endDate: LocalDate, issueStatuses: List<IssuedStatus>, pageable: Pageable): Page<ReportedAdjudicationDto> {
+    if (issueStatuses.containsAll(IssuedStatus.values().toList()))
+      return reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationId(
+        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), locationId = locationId!!, pageable = pageable
+      ).map { it.toDto() }
+    if (issueStatuses.contains(IssuedStatus.ISSUED))
+      return reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationIdAndDateTimeOfIssueIsNotNull(
+        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), locationId = locationId!!, pageable = pageable
+      ).map { it.toDto() }
+    if (issueStatuses.contains(IssuedStatus.NOT_ISSUED))
+      return reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationIdAndDateTimeOfIssueIsNull(
+        agencyId = agencyId, startDate = reportsFrom(startDate), endDate = reportsTo(endDate), statuses = ReportedAdjudicationStatus.issuableStatuses(), locationId = locationId!!, pageable = pageable
+      ).map { it.toDto() }
+
+    return Page.empty()
   }
 
   companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/ReportsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/ReportsControllerTest.kt
@@ -128,11 +128,11 @@ class ReportsControllerTest : TestControllerBase() {
   @Test
   @WithMockUser(username = "ITAG_USER")
   fun `get adjudications for issue with defaulted dates`() {
-    whenever(reportsService.getAdjudicationsForIssue("MDI", 1L, LocalDate.now().minusDays(2), LocalDate.now(), pageRequest))
+    whenever(reportsService.getAdjudicationsForIssue("MDI", 1L, LocalDate.now().minusDays(2), LocalDate.now(), null, pageRequest))
       .thenReturn(Page.empty())
 
     getAdjudicationsForIssue().andExpect(MockMvcResultMatchers.status().isOk)
-    verify(reportsService).getAdjudicationsForIssue("MDI", 1L, LocalDate.now().minusDays(2), LocalDate.now(), pageRequest)
+    verify(reportsService).getAdjudicationsForIssue("MDI", 1L, LocalDate.now().minusDays(2), LocalDate.now(), null, pageRequest)
   }
 
   private fun getMyAdjudications(): ResultActions {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReportedAdjudicationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReportedAdjudicationIntTest.kt
@@ -997,6 +997,36 @@ class ReportedAdjudicationIntTest : IntegrationTestBase() {
       .jsonPath("$.content[0].issuingOfficer").isEqualTo(IntegrationTestData.DEFAULT_ADJUDICATION.createdByUserId)
   }
 
+  @Test
+  fun `get issued adjudications for all locations in agency MDI for date range`() {
+    prisonApiMockServer.stubPostAdjudication(IntegrationTestData.DEFAULT_ADJUDICATION)
+
+    initMyReportData() // ensure more data to filter out
+
+    val intTestData = integrationTestData()
+    val underTestHeaders = setHeaders(username = IntegrationTestData.DEFAULT_ADJUDICATION.createdByUserId)
+    val underTestDraftIntTestScenarioBuilder = IntegrationTestScenarioBuilder(intTestData, this, underTestHeaders)
+    underTestDraftIntTestScenarioBuilder
+      .startDraft(IntegrationTestData.DEFAULT_ADJUDICATION)
+      .setApplicableRules()
+      .setIncidentRole()
+      .setAssociatedPrisoner()
+      .setOffenceData()
+      .addIncidentStatement()
+      .completeDraft()
+      .acceptReport(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber.toString())
+      .issueReport(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber.toString())
+
+    webTestClient.get()
+      .uri("/reported-adjudications/agency/MDI/issue?issueStatus=ISSUED&startDate=2010-11-12&endDate=2020-12-16&page=0&size=20")
+      .headers(setHeaders())
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.content.size()").isEqualTo(1)
+      .jsonPath("$.content[0].issuingOfficer").isEqualTo(IntegrationTestData.DEFAULT_ADJUDICATION.createdByUserId)
+  }
+
   private fun initMyReportData() {
     val intTestData = integrationTestData()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReportedAdjudicationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReportedAdjudicationIntTest.kt
@@ -1027,6 +1027,35 @@ class ReportedAdjudicationIntTest : IntegrationTestBase() {
       .jsonPath("$.content[0].issuingOfficer").isEqualTo(IntegrationTestData.DEFAULT_ADJUDICATION.createdByUserId)
   }
 
+  @Test
+  fun `get not issued adjudications for all locations in agency MDI for date range`() {
+    prisonApiMockServer.stubPostAdjudication(IntegrationTestData.DEFAULT_ADJUDICATION)
+
+    initMyReportData() // ensure more data to filter out
+
+    val intTestData = integrationTestData()
+    val underTestHeaders = setHeaders(username = IntegrationTestData.DEFAULT_ADJUDICATION.createdByUserId)
+    val underTestDraftIntTestScenarioBuilder = IntegrationTestScenarioBuilder(intTestData, this, underTestHeaders)
+    underTestDraftIntTestScenarioBuilder
+      .startDraft(IntegrationTestData.DEFAULT_ADJUDICATION)
+      .setApplicableRules()
+      .setIncidentRole()
+      .setAssociatedPrisoner()
+      .setOffenceData()
+      .addIncidentStatement()
+      .completeDraft()
+      .acceptReport(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber.toString())
+
+    webTestClient.get()
+      .uri("/reported-adjudications/agency/MDI/issue?issueStatus=NOT_ISSUED&startDate=2010-11-12&endDate=2020-12-16&page=0&size=20")
+      .headers(setHeaders())
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.content.size()").isEqualTo(1)
+      .jsonPath("$.content[0].issuingOfficer").doesNotExist()
+  }
+
   private fun initMyReportData() {
     val intTestData = integrationTestData()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepositoryTest.kt
@@ -48,6 +48,18 @@ class ReportedAdjudicationRepositoryTest {
     entityManager.persistAndFlush(entityBuilder.reportedAdjudication(reportNumber = 1235L, dateTime = dateTimeOfIncident.plusHours(1), hearingId = null))
     entityManager.persistAndFlush(entityBuilder.reportedAdjudication(reportNumber = 1236L, dateTime = dateTimeOfIncident.plusHours(1), agencyId = "LEI", hearingId = null))
     entityManager.persistAndFlush(entityBuilder.reportedAdjudication(reportNumber = 9999L, dateTime = dateTimeOfIncident.plusHours(1), agencyId = "TJW", hearingId = null).also { it.status = ReportedAdjudicationStatus.UNSCHEDULED })
+    entityManager.persistAndFlush(
+      entityBuilder.reportedAdjudication(reportNumber = 9998L, dateTime = dateTimeOfIncident.plusHours(1), agencyId = "XXX", hearingId = null).also {
+        it.status = ReportedAdjudicationStatus.UNSCHEDULED
+        it.dateTimeOfIssue = LocalDateTime.now()
+      }
+    )
+    entityManager.persistAndFlush(
+      entityBuilder.reportedAdjudication(reportNumber = 9997L, dateTime = dateTimeOfIncident.plusHours(1), agencyId = "LEI", hearingId = null).also {
+        it.status = ReportedAdjudicationStatus.UNSCHEDULED
+        it.dateTimeOfIssue = LocalDateTime.now()
+      }
+    )
   }
 
   @Test
@@ -239,6 +251,44 @@ class ReportedAdjudicationRepositoryTest {
       LocalDate.now().plusDays(1).atTime(
         LocalTime.MAX
       ),
+      ReportedAdjudicationStatus.values().toList().filter { it != ReportedAdjudicationStatus.UNSCHEDULED },
+      Pageable.ofSize(10)
+    )
+
+    assertThat(foundAdjudications.content).hasSize(1)
+      .extracting("reportNumber")
+      .contains(
+        1236L
+      )
+  }
+
+  @Test
+  fun `find reported adjudications by agency id and issue is not null`() {
+    val foundAdjudications = reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndDateTimeOfIssueIsNotNull(
+      "LEI",
+      LocalDate.now().plusDays(1).atStartOfDay(),
+      LocalDate.now().plusDays(1).atTime(
+        LocalTime.MAX
+      ),
+      ReportedAdjudicationStatus.values().toList(),
+      Pageable.ofSize(10)
+    )
+
+    assertThat(foundAdjudications.content).hasSize(1)
+      .extracting("reportNumber")
+      .contains(
+        9997L
+      )
+  }
+
+  @Test
+  fun `find reported adjudications by agency id and issue is null`() {
+    val foundAdjudications = reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndDateTimeOfIssueIsNull(
+      "LEI",
+      LocalDate.now().plusDays(1).atStartOfDay(),
+      LocalDate.now().plusDays(1).atTime(
+        LocalTime.MAX
+      ),
       ReportedAdjudicationStatus.values().toList(),
       Pageable.ofSize(10)
     )
@@ -318,6 +368,46 @@ class ReportedAdjudicationRepositoryTest {
   @Test
   fun `get all adjudications to issue by agency, date, location id `() {
     val adjudications = reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationId(
+      "TJW",
+      LocalDate.now().plusDays(1).atStartOfDay(),
+      LocalDate.now().plusDays(1).atTime(
+        LocalTime.MAX
+      ),
+      listOf(ReportedAdjudicationStatus.UNSCHEDULED, ReportedAdjudicationStatus.SCHEDULED),
+      2,
+      Pageable.ofSize(10)
+    )
+
+    assertThat(adjudications.content).hasSize(1)
+      .extracting("reportNumber")
+      .contains(
+        9999L
+      )
+  }
+
+  @Test
+  fun `get all adjudications to issue by agency, date, location id and issue is not null `() {
+    val adjudications = reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationIdAndDateTimeOfIssueIsNotNull(
+      "XXX",
+      LocalDate.now().plusDays(1).atStartOfDay(),
+      LocalDate.now().plusDays(1).atTime(
+        LocalTime.MAX
+      ),
+      listOf(ReportedAdjudicationStatus.UNSCHEDULED, ReportedAdjudicationStatus.SCHEDULED),
+      2,
+      Pageable.ofSize(10)
+    )
+
+    assertThat(adjudications.content).hasSize(1)
+      .extracting("reportNumber")
+      .contains(
+        9998L
+      )
+  }
+
+  @Test
+  fun `get all adjudications to issue by agency, date, location id and issue is null `() {
+    val adjudications = reportedAdjudicationRepository.findByAgencyIdAndDateTimeOfDiscoveryBetweenAndStatusInAndLocationIdAndDateTimeOfIssueIsNull(
       "TJW",
       LocalDate.now().plusDays(1).atStartOfDay(),
       LocalDate.now().plusDays(1).atTime(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportsServiceTest.kt
@@ -10,7 +10,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.IssuedStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 import java.time.LocalDate
 import java.time.LocalDateTime


### PR DESCRIPTION
raised separate TD ticket to refactor out the integration tests as file getting large.

Note: given issued is boolean (ie its issued or not) the assumption is that for ALL cases, or no case (ie its optional for other endpoints) same logic applies as ALL == nothing