### PR TITLE
NN-4832

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeController.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.NotProceedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.OutcomeService
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.ReferralService
 
 @Schema(description = "Request to add an outcome")
 data class OutcomeRequest(
@@ -26,7 +28,8 @@ data class OutcomeRequest(
 @PreAuthorize("hasRole('ADJUDICATIONS_REVIEWER') and hasAuthority('SCOPE_write')")
 @RestController
 class OutcomeController(
-  private val outcomeService: OutcomeService
+  private val outcomeService: OutcomeService,
+  private val referralService: ReferralService,
 ) : ReportedAdjudicationBaseController() {
 
   @Operation(summary = "create an outcome")
@@ -41,6 +44,19 @@ class OutcomeController(
       code = outcomeRequest.code,
       details = outcomeRequest.details,
       reason = outcomeRequest.reason,
+    )
+
+    return ReportedAdjudicationResponse(reportedAdjudication)
+  }
+
+  @Operation(summary = "remove a referral")
+  @DeleteMapping(value = ["/{adjudicationNumber}/remove-referral"])
+  @ResponseStatus(HttpStatus.CREATED)
+  fun removeReferral(
+    @PathVariable(name = "adjudicationNumber") adjudicationNumber: Long,
+  ): ReportedAdjudicationResponse {
+    val reportedAdjudication = referralService.removeReferral(
+      adjudicationNumber = adjudicationNumber
     )
 
     return ReportedAdjudicationResponse(reportedAdjudication)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
@@ -11,7 +11,6 @@ import javax.persistence.Enumerated
 import javax.persistence.FetchType
 import javax.persistence.JoinColumn
 import javax.persistence.OneToMany
-import javax.persistence.OneToOne
 import javax.persistence.Table
 import javax.validation.ValidationException
 
@@ -62,9 +61,9 @@ data class ReportedAdjudication(
   var issuingOfficer: String? = null,
   var dateTimeOfIssue: LocalDateTime? = null,
   var dateTimeOfFirstHearing: LocalDateTime? = null,
-  @OneToOne(optional = true, cascade = [CascadeType.ALL], fetch = FetchType.EAGER)
-  @JoinColumn(name = "outcome_id")
-  var outcome: Outcome? = null,
+  @OneToMany(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+  @JoinColumn(name = "reported_adjudication_fk_id")
+  var outcomes: MutableList<Outcome>,
 
 ) :
   BaseEntity() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/AdjudicationWorkflowService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/AdjudicationWorkflowService.kt
@@ -166,7 +166,8 @@ class AdjudicationWorkflowService(
         evidence = toReportedEvidence(draftAdjudication.evidence),
         witnesses = toReportedWitnesses(draftAdjudication.witnesses),
         draftCreatedOn = draftAdjudication.createDateTime!!,
-        hearings = mutableListOf()
+        hearings = mutableListOf(),
+        outcomes = mutableListOf(),
       )
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeService.kt
@@ -83,7 +83,7 @@ class HearingOutcomeService(
         outcomeToAmend.finding = null
       }
       else -> {
-        outcomeToAmend.details = details
+        outcomeToAmend.details = null
         outcomeToAmend.reason = null
         outcomeToAmend.plea = null
         outcomeToAmend.finding = null
@@ -107,9 +107,7 @@ class HearingOutcomeService(
           validateField(this.reason)
           validateField(this.plea)
         }
-        else -> {
-          validateField(this.details)
-        }
+        else -> {}
       }
       return this
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeService.kt
@@ -95,6 +95,10 @@ class HearingOutcomeService(
     return saveToDto(reportedAdjudication)
   }
 
+  fun deleteHearingOutcome(adjudicationNumber: Long): ReportedAdjudicationDto {
+    TODO("implement me")
+  }
+
   companion object {
     fun HearingOutcome.validate(): HearingOutcome {
       when (this.code) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeService.kt
@@ -95,7 +95,7 @@ class HearingOutcomeService(
     return saveToDto(reportedAdjudication)
   }
 
-  fun deleteHearingOutcome(adjudicationNumber: Long): ReportedAdjudicationDto {
+  fun deleteHearingOutcome(adjudicationNumber: Long, hearingId: Long): ReportedAdjudicationDto {
     TODO("implement me")
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
@@ -38,16 +38,22 @@ class OutcomeService(
       }
     }
 
-    reportedAdjudication.outcome = Outcome(
-      code = code,
-      details = details,
-      reason = reason,
+    reportedAdjudication.outcomes.add(
+      Outcome(
+        code = code,
+        details = details,
+        reason = reason,
+      )
     )
 
     return saveToDto(reportedAdjudication)
   }
 
   fun deleteOutcome(adjudicationNumber: Long): ReportedAdjudicationDto {
+    TODO("implement me")
+  }
+
+  fun isReferral(adjudicationNumber: Long): Boolean {
     TODO("implement me")
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
@@ -47,6 +47,10 @@ class OutcomeService(
     return saveToDto(reportedAdjudication)
   }
 
+  fun deleteOutcome(adjudicationNumber: Long): ReportedAdjudicationDto {
+    TODO("implement me")
+  }
+
   companion object {
     private fun validateDetails(details: String?) = details ?: throw ValidationException("details are required")
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralService.kt
@@ -24,7 +24,6 @@ class ReferralService(
       hearingId = hearingId,
       code = code,
       adjudicator = adjudicator,
-      details = details
     )
     return outcomeService.createOutcome(
       adjudicationNumber = adjudicationNumber,
@@ -45,7 +44,6 @@ class ReferralService(
       hearingId = hearingId,
       code = code,
       adjudicator = adjudicator,
-      details = details
     )
     // TODO not implemented update outcome yet.  later tickets, plus can remove a referral too.
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralService.kt
@@ -47,4 +47,8 @@ class ReferralService(
     )
     // TODO not implemented update outcome yet.  later tickets, plus can remove a referral too.
   }
+
+  fun removeReferral(adjudicationNumber: Long): ReportedAdjudicationDto {
+    TODO("implement me")
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -61,12 +61,12 @@ open class ReportedDtoService(
     status = status,
     statusReason = statusReason,
     statusDetails = statusDetails,
-    hearings = toHearings(hearings, outcome),
+    hearings = toHearings(hearings, outcomes.firstOrNull()),
     issuingOfficer = issuingOfficer,
     dateTimeOfIssue = dateTimeOfIssue,
     gender = gender,
     dateTimeOfFirstHearing = dateTimeOfFirstHearing,
-    outcome = outcome?.toOutcomeDto()
+    outcome = outcomes.firstOrNull()?.toOutcomeDto()
   )
 
   private fun toReportedOffence(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -61,7 +61,7 @@ open class ReportedDtoService(
     status = status,
     statusReason = statusReason,
     statusDetails = statusDetails,
-    hearings = toHearings(hearings),
+    hearings = toHearings(hearings, outcome),
     issuingOfficer = issuingOfficer,
     dateTimeOfIssue = dateTimeOfIssue,
     gender = gender,
@@ -115,23 +115,23 @@ open class ReportedDtoService(
       )
     }.toList()
 
-  private fun toHearings(hearings: MutableList<Hearing>): List<HearingDto> =
+  private fun toHearings(hearings: MutableList<Hearing>, outcome: Outcome?): List<HearingDto> =
     hearings.map {
       HearingDto(
         id = it.id,
         locationId = it.locationId,
         dateTimeOfHearing = it.dateTimeOfHearing,
         oicHearingType = it.oicHearingType,
-        outcome = it.hearingOutcome?.toHearingOutcomeDto()
+        outcome = it.hearingOutcome?.toHearingOutcomeDto(outcome)
       )
     }.sortedBy { it.dateTimeOfHearing }.toList()
 
-  private fun HearingOutcome.toHearingOutcomeDto(): HearingOutcomeDto =
+  private fun HearingOutcome.toHearingOutcomeDto(outcome: Outcome?): HearingOutcomeDto =
     HearingOutcomeDto(
       id = this.id,
       code = this.code,
       reason = this.reason,
-      details = this.details,
+      details = if (this.code.outcomeCode != null) outcome?.details else this.details,
       adjudicator = this.adjudicator,
       finding = this.finding,
       plea = this.plea,

--- a/src/main/resources/db/migration/V51__outcomes_is_one_too_many.sql
+++ b/src/main/resources/db/migration/V51__outcomes_is_one_too_many.sql
@@ -1,0 +1,6 @@
+alter table reported_adjudications drop constraint fk_adjudication_outcome;
+alter table reported_adjudications drop column outcome_id;
+drop index if exists reported_adjudications_outcome_idx;
+alter table outcome ADD COLUMN reported_adjudication_fk_id bigint references reported_adjudications (id);
+create index outcomes_adjudication_fk_idx on outcome(reported_adjudication_fk_id);
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
@@ -294,6 +294,8 @@ class HearingsIntTest : IntegrationTestBase() {
       .jsonPath("$.reportedAdjudication.hearings[0].outcome.reason").doesNotExist()
       .jsonPath("$.reportedAdjudication.hearings[0].outcome.plea").doesNotExist()
       .jsonPath("$.reportedAdjudication.hearings[0].outcome.finding").doesNotExist()
+      .jsonPath("$.reportedAdjudication.hearings[0].outcome.details")
+      .isEqualTo("details")
       .jsonPath("$.reportedAdjudication.hearings[0].outcome.code").isEqualTo(HearingOutcomeCode.REFER_POLICE.name)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
@@ -294,8 +294,6 @@ class HearingsIntTest : IntegrationTestBase() {
       .jsonPath("$.reportedAdjudication.hearings[0].outcome.reason").doesNotExist()
       .jsonPath("$.reportedAdjudication.hearings[0].outcome.plea").doesNotExist()
       .jsonPath("$.reportedAdjudication.hearings[0].outcome.finding").doesNotExist()
-      .jsonPath("$.reportedAdjudication.hearings[0].outcome.details")
-      .isEqualTo("details")
       .jsonPath("$.reportedAdjudication.hearings[0].outcome.code").isEqualTo(HearingOutcomeCode.REFER_POLICE.name)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
@@ -436,6 +436,25 @@ class HearingsIntTest : IntegrationTestBase() {
       .isEqualTo(reportedAdjudication.reportedAdjudication.hearings.first().oicHearingType.name)
   }
 
+  @Test
+  @Disabled
+  fun `remove referral with hearing`() {
+    prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    val reportedAdjudication = initDataForHearings().createHearing()
+    integrationTestData().createHearingOutcome(
+      reportedAdjudication.reportedAdjudication.adjudicationNumber, reportedAdjudication.reportedAdjudication.hearings.first().id!!, HearingOutcomeCode.REFER_POLICE
+    )
+
+    webTestClient.delete()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/remove-referral")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.outcome").doesNotExist()
+      .jsonPath("$.reportedAdjudication.hearings[0].outcome").doesNotExist()
+  }
+
   private fun initDataForHearings(): IntegrationTestScenario {
     prisonApiMockServer.stubPostAdjudication(IntegrationTestData.DEFAULT_ADJUDICATION)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Evidenc
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeAdjournReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomePlea
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.WitnessCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OicHearingType
@@ -531,6 +532,21 @@ class IntegrationTestData(
       .exchange()
   }
 
+  fun createOutcome(
+    reportNumber: String,
+  ): WebTestClient.ResponseSpec {
+    return webTestClient.post()
+      .uri("/reported-adjudications/$reportNumber/outcome")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .bodyValue(
+        mapOf(
+          "code" to OutcomeCode.REFER_POLICE,
+          "details" to "details",
+        )
+      )
+      .exchange()
+  }
+
   fun createHearing(
     testDataSet: AdjudicationIntTestDataSet,
   ): ReportedAdjudicationResponse {
@@ -553,17 +569,18 @@ class IntegrationTestData(
   fun createHearingOutcome(
     adjudicationNumber: Long,
     hearingId: Long,
+    code: HearingOutcomeCode? = HearingOutcomeCode.ADJOURN
   ): ReportedAdjudicationResponse {
     return webTestClient.post()
       .uri("/reported-adjudications/$adjudicationNumber/hearing/$hearingId/outcome")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
-          "code" to HearingOutcomeCode.ADJOURN.name,
+          "code" to code,
           "details" to "details",
           "adjudicator" to "testing",
-          "reason" to HearingOutcomeAdjournReason.LEGAL_ADVICE.name,
-          "plea" to HearingOutcomePlea.UNFIT.name,
+          "reason" to HearingOutcomeAdjournReason.LEGAL_ADVICE,
+          "plea" to HearingOutcomePlea.UNFIT,
         )
       )
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestScenarioBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestScenarioBuilder.kt
@@ -85,6 +85,12 @@ class IntegrationTestScenario(
     )
   }
 
+  fun createOutcome(reportNumber: String): IntegrationTestScenario {
+    intTestData.createOutcome(reportNumber)
+
+    return this
+  }
+
   fun issueReport(reportNumber: String): IntegrationTestScenario {
     intTestData.issueReport(
       draftCreationResponse,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
@@ -37,6 +37,16 @@ class OutcomeIntTest : IntegrationTestBase() {
       .jsonPath("$.reportedAdjudication.outcome.code").isEqualTo(OutcomeCode.NOT_PROCEED.name)
   }
 
+  @Test
+  fun `remove referral with hearing`() {
+    TODO("implement me")
+  }
+
+  @Test
+  fun `remove referral without hearing`() {
+    TODO("implement me")
+  }
+
   private fun initDataForOutcome(): IntegrationTestScenario {
     prisonApiMockServer.stubPostAdjudication(IntegrationTestData.DEFAULT_ADJUDICATION)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration
 
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.NotProceedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
@@ -21,9 +22,9 @@ class OutcomeIntTest : IntegrationTestBase() {
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
-          "code" to OutcomeCode.NOT_PROCEED.name,
+          "code" to OutcomeCode.NOT_PROCEED,
           "details" to "details",
-          "reason" to NotProceedReason.NOT_FAIR.name,
+          "reason" to NotProceedReason.NOT_FAIR,
         )
       )
       .exchange()
@@ -38,13 +39,17 @@ class OutcomeIntTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `remove referral with hearing`() {
-    TODO("implement me")
-  }
-
-  @Test
+  @Disabled
   fun `remove referral without hearing`() {
-    TODO("implement me")
+    initDataForOutcome().createOutcome(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber.toString())
+
+    webTestClient.delete()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/remove-referral")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.outcome").doesNotExist()
   }
 
   private fun initDataForOutcome(): IntegrationTestScenario {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepositoryTest.kt
@@ -458,10 +458,10 @@ class ReportedAdjudicationRepositoryTest {
   @Test
   fun `adjudication outcome`() {
     val adjudication = reportedAdjudicationRepository.findByReportNumber(1236L)
-    adjudication!!.outcome = Outcome(code = OutcomeCode.REFER_POLICE)
+    adjudication!!.outcomes.add(Outcome(code = OutcomeCode.REFER_POLICE))
 
     val savedEntity = reportedAdjudicationRepository.save(adjudication)
 
-    assertThat(savedEntity.outcome!!.code).isEqualTo(OutcomeCode.REFER_POLICE)
+    assertThat(savedEntity.outcomes.first().code).isEqualTo(OutcomeCode.REFER_POLICE)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeServiceTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.report
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -388,6 +389,7 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
     }
   }
 
+  @Disabled
   @Nested
   inner class DeleteHearingOutcome {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeServiceTest.kt
@@ -387,4 +387,13 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
       assertThat(response).isNotNull
     }
   }
+
+  @Nested
+  inner class DeleteHearingOutcome {
+
+    @Test
+    fun `delete hearing outcome`() {
+      TODO("implement me")
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeServiceTest.kt
@@ -126,7 +126,7 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
     }
 
     @ParameterizedTest
-    @CsvSource("REFER_POLICE", "REFER_INAD", "ADJOURN")
+    @CsvSource("ADJOURN")
     fun `validation details for bad refer request`(code: HearingOutcomeCode) {
       Assertions.assertThatThrownBy {
         hearingOutcomeService.createHearingOutcome(
@@ -218,15 +218,14 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
         hearingId = 1,
         code = code,
         adjudicator = "updated test",
-        details = "updated details",
       )
 
       verify(reportedAdjudicationRepository).save(argumentCaptor.capture())
 
       assertThat(argumentCaptor.value.hearings.first().hearingOutcome).isNotNull
       assertThat(argumentCaptor.value.hearings.first().hearingOutcome!!.adjudicator).isEqualTo("updated test")
-      assertThat(argumentCaptor.value.hearings.first().hearingOutcome!!.details).isEqualTo("updated details")
       assertThat(argumentCaptor.value.hearings.first().hearingOutcome!!.code).isEqualTo(code)
+      assertThat(argumentCaptor.value.hearings.first().hearingOutcome!!.details).isNull()
       assertThat(argumentCaptor.value.hearings.first().hearingOutcome!!.reason).isNull()
       assertThat(argumentCaptor.value.hearings.first().hearingOutcome!!.finding).isNull()
       assertThat(argumentCaptor.value.hearings.first().hearingOutcome!!.plea).isNull()
@@ -341,7 +340,7 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
     }
 
     @ParameterizedTest
-    @CsvSource("REFER_POLICE", "REFER_INAD", "ADJOURN")
+    @CsvSource("ADJOURN")
     fun `validation of details for bad request`(code: HearingOutcomeCode) {
       Assertions.assertThatThrownBy {
         hearingOutcomeService.updateHearingOutcome(
@@ -379,7 +378,7 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
 
       assertThat(argumentCaptor.value.hearings.first().hearingOutcome).isNotNull
       assertThat(argumentCaptor.value.hearings.first().hearingOutcome!!.adjudicator).isEqualTo("updated test")
-      assertThat(argumentCaptor.value.hearings.first().hearingOutcome!!.details).isEqualTo(request.details)
+      request.code.outcomeCode ?: assertThat(argumentCaptor.value.hearings.first().hearingOutcome!!.details).isEqualTo(request.details)
       assertThat(argumentCaptor.value.hearings.first().hearingOutcome!!.code).isEqualTo(request.code)
       assertThat(argumentCaptor.value.hearings.first().hearingOutcome!!.reason).isEqualTo(request.reason)
       assertThat(argumentCaptor.value.hearings.first().hearingOutcome!!.finding).isEqualTo(request.finding)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
@@ -113,4 +113,13 @@ class OutcomeServiceTest : ReportedAdjudicationTestBase() {
       assertThat(response).isNotNull
     }
   }
+
+  @Nested
+  inner class DeleteOutcome {
+
+    @Test
+    fun `delete outcome `() {
+      TODO("implement me")
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.report
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -12,7 +13,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.NotProceedReason
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Outcome
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudication
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
@@ -46,11 +46,7 @@ class OutcomeServiceTest : ReportedAdjudicationTestBase() {
           it.createDateTime = LocalDateTime.now()
         }
       )
-      whenever(reportedAdjudicationRepository.save(any())).thenReturn(
-        reportedAdjudication.also {
-          it.outcome = Outcome(code = OutcomeCode.REFER_POLICE)
-        }
-      )
+      whenever(reportedAdjudicationRepository.save(any())).thenReturn(reportedAdjudication)
     }
 
     @ParameterizedTest
@@ -105,18 +101,22 @@ class OutcomeServiceTest : ReportedAdjudicationTestBase() {
 
       verify(reportedAdjudicationRepository).save(argumentCaptor.capture())
 
-      assertThat(argumentCaptor.value.outcome).isNotNull
-      assertThat(argumentCaptor.value.outcome!!.code).isEqualTo(code)
-      assertThat(argumentCaptor.value.outcome!!.details).isEqualTo("details")
+      assertThat(argumentCaptor.value.outcomes.first()).isNotNull
+      assertThat(argumentCaptor.value.outcomes.first().code).isEqualTo(code)
+      assertThat(argumentCaptor.value.outcomes.first().details).isEqualTo("details")
       assertThat(argumentCaptor.value.status).isEqualTo(ReportedAdjudicationStatus.valueOf(code.name))
-      assertThat(argumentCaptor.value.outcome!!.reason).isEqualTo(NotProceedReason.RELEASED)
+      assertThat(argumentCaptor.value.outcomes.first().reason).isEqualTo(NotProceedReason.RELEASED)
       assertThat(response).isNotNull
     }
   }
 
   @Nested
+  @Disabled
   inner class DeleteOutcome {
 
+    fun `is referral`() {
+      TODO("implement me")
+    }
     @Test
     fun `delete outcome `() {
       TODO("implement me")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralServiceTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
@@ -52,6 +53,26 @@ class ReferralServiceTest : ReportedAdjudicationTestBase() {
       )
 
       // TODO not implemented yet verify(outcomeService, atLeastOnce()).createOutcome(adjudicationNumber = 1, code = OutcomeCode.REFER_POLICE, details = "details 2")
+    }
+  }
+
+  @Nested
+  inner class RemoveReferral {
+
+    @Test
+    fun `remove referral should only remove outcome`() {
+      referralService.removeReferral(1)
+
+      verify(outcomeService, atLeastOnce()).deleteOutcome(1)
+      verify(hearingOutcomeService, never()).deleteHearingOutcome(1)
+    }
+
+    @Test
+    fun `remove referral should remove outcome and hearing outcome`() {
+      referralService.removeReferral(1)
+
+      verify(outcomeService, atLeastOnce()).deleteOutcome(1)
+      verify(hearingOutcomeService, atLeastOnce()).deleteHearingOutcome(1)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralServiceTest.kt
@@ -30,7 +30,7 @@ class ReferralServiceTest : ReportedAdjudicationTestBase() {
       )
 
       verify(hearingOutcomeService, atLeastOnce()).createHearingOutcome(
-        adjudicationNumber = 1, hearingId = 1, code = HearingOutcomeCode.REFER_POLICE, adjudicator = "test", details = "details"
+        adjudicationNumber = 1, hearingId = 1, code = HearingOutcomeCode.REFER_POLICE, adjudicator = "test",
       )
 
       verify(outcomeService, atLeastOnce()).createOutcome(adjudicationNumber = 1, code = OutcomeCode.REFER_POLICE, details = "details")
@@ -48,7 +48,7 @@ class ReferralServiceTest : ReportedAdjudicationTestBase() {
       )
 
       verify(hearingOutcomeService, atLeastOnce()).updateHearingOutcome(
-        adjudicationNumber = 1, hearingId = 1, code = HearingOutcomeCode.REFER_INAD, adjudicator = "test 2", details = "details 2"
+        adjudicationNumber = 1, hearingId = 1, code = HearingOutcomeCode.REFER_INAD, adjudicator = "test 2",
       )
 
       // TODO not implemented yet verify(outcomeService, atLeastOnce()).createOutcome(adjudicationNumber = 1, code = OutcomeCode.REFER_POLICE, details = "details 2")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralServiceTest.kt
@@ -1,13 +1,16 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported
 
-import org.junit.jupiter.api.Nested
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
+import javax.validation.ValidationException
 
 class ReferralServiceTest : ReportedAdjudicationTestBase() {
 
@@ -20,59 +23,64 @@ class ReferralServiceTest : ReportedAdjudicationTestBase() {
     // not applicable
   }
 
-  @Nested
-  inner class CreateReferral {
+  @Test
+  fun `create outcome and hearing outcome for referral`() {
 
-    @Test
-    fun `create outcome and hearing outcome for referral`() {
+    referralService.createReferral(
+      1, 1, HearingOutcomeCode.REFER_POLICE, "test", "details",
+    )
 
-      referralService.createReferral(
-        1, 1, HearingOutcomeCode.REFER_POLICE, "test", "details",
-      )
+    verify(hearingOutcomeService, atLeastOnce()).createHearingOutcome(
+      adjudicationNumber = 1, hearingId = 1, code = HearingOutcomeCode.REFER_POLICE, adjudicator = "test",
+    )
 
-      verify(hearingOutcomeService, atLeastOnce()).createHearingOutcome(
-        adjudicationNumber = 1, hearingId = 1, code = HearingOutcomeCode.REFER_POLICE, adjudicator = "test",
-      )
-
-      verify(outcomeService, atLeastOnce()).createOutcome(adjudicationNumber = 1, code = OutcomeCode.REFER_POLICE, details = "details")
-    }
+    verify(outcomeService, atLeastOnce()).createOutcome(adjudicationNumber = 1, code = OutcomeCode.REFER_POLICE, details = "details")
   }
 
-  @Nested
-  inner class UpdateReferral {
+  @Test
+  fun `updates outcome and hearing outcome for referral`() {
 
-    @Test
-    fun `updates outcome and hearing outcome for referral`() {
+    referralService.updateReferral(
+      1, 1, HearingOutcomeCode.REFER_INAD, "test 2", "details 2",
+    )
 
-      referralService.updateReferral(
-        1, 1, HearingOutcomeCode.REFER_INAD, "test 2", "details 2",
-      )
+    verify(hearingOutcomeService, atLeastOnce()).updateHearingOutcome(
+      adjudicationNumber = 1, hearingId = 1, code = HearingOutcomeCode.REFER_INAD, adjudicator = "test 2",
+    )
 
-      verify(hearingOutcomeService, atLeastOnce()).updateHearingOutcome(
-        adjudicationNumber = 1, hearingId = 1, code = HearingOutcomeCode.REFER_INAD, adjudicator = "test 2",
-      )
-
-      // TODO not implemented yet verify(outcomeService, atLeastOnce()).createOutcome(adjudicationNumber = 1, code = OutcomeCode.REFER_POLICE, details = "details 2")
-    }
+    // TODO not implemented yet verify(outcomeService, atLeastOnce()).createOutcome(adjudicationNumber = 1, code = OutcomeCode.REFER_POLICE, details = "details 2")
   }
 
-  @Nested
-  inner class RemoveReferral {
+  @Test
+  @Disabled
+  fun `remove referral should only remove outcome`() {
+    whenever(outcomeService.isReferral(1)).thenReturn(true)
 
-    @Test
-    fun `remove referral should only remove outcome`() {
-      referralService.removeReferral(1)
+    referralService.removeReferral(1)
 
-      verify(outcomeService, atLeastOnce()).deleteOutcome(1)
-      verify(hearingOutcomeService, never()).deleteHearingOutcome(1)
-    }
+    verify(outcomeService, atLeastOnce()).deleteOutcome(1)
+    verify(hearingOutcomeService, never()).deleteHearingOutcome(1, 1)
+  }
 
-    @Test
-    fun `remove referral should remove outcome and hearing outcome`() {
-      referralService.removeReferral(1)
+  @Test
+  @Disabled
+  fun `remove referral should remove outcome and hearing outcome`() {
+    whenever(outcomeService.isReferral(1)).thenReturn(true)
 
-      verify(outcomeService, atLeastOnce()).deleteOutcome(1)
-      verify(hearingOutcomeService, atLeastOnce()).deleteHearingOutcome(1)
-    }
+    referralService.removeReferral(1)
+
+    verify(outcomeService, atLeastOnce()).deleteOutcome(1)
+    verify(hearingOutcomeService, atLeastOnce()).deleteHearingOutcome(1, 1)
+  }
+
+  @Test
+  @Disabled
+  fun `responds with bad request if no referral on adjudication`() {
+    whenever(outcomeService.isReferral(1)).thenReturn(false)
+
+    Assertions.assertThatThrownBy {
+      referralService.removeReferral(1,)
+    }.isInstanceOf(ValidationException::class.java)
+      .hasMessageContaining("No referral for adjudication")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/utils/EntityBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/utils/EntityBuilder.kt
@@ -82,7 +82,8 @@ class EntityBuilder {
           oicHearingId = 3L,
           oicHearingType = OicHearingType.GOV,
         )
-      )
+      ),
+      outcomes = mutableListOf(),
     )
   }
 }


### PR DESCRIPTION
breaking this down into two parts - first part is the refactoring and change to model

This PR includes
 1: outcomes is now a list at the database level
 2: Note, outcomes is still a single object at DTO level 
 3: remove details from the hearing outcome for referrals, it is stored against the outcome 