### PR TITLE
NN-4849

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingController.kt
@@ -75,37 +75,39 @@ class HearingController(
     @RequestBody hearingRequest: HearingRequest
   ): ReportedAdjudicationResponse {
     val reportedAdjudication = hearingService.createHearing(
-      adjudicationNumber, hearingRequest.locationId, hearingRequest.dateTimeOfHearing, hearingRequest.oicHearingType,
+      adjudicationNumber = adjudicationNumber,
+      locationId = hearingRequest.locationId,
+      dateTimeOfHearing = hearingRequest.dateTimeOfHearing,
+      oicHearingType = hearingRequest.oicHearingType,
     )
 
     return ReportedAdjudicationResponse(reportedAdjudication)
   }
 
-  @PutMapping(value = ["/{adjudicationNumber}/hearing/{hearingId}"])
-  @Operation(summary = "Amend an existing hearing")
+  @PutMapping(value = ["/{adjudicationNumber}/hearing"])
+  @Operation(summary = "Amends leatest hearing")
   @ResponseStatus(HttpStatus.OK)
   fun amendHearing(
     @PathVariable(name = "adjudicationNumber") adjudicationNumber: Long,
-    @PathVariable(name = "hearingId") hearingId: Long,
     @RequestBody hearingRequest: HearingRequest
   ): ReportedAdjudicationResponse {
     val reportedAdjudication = hearingService.amendHearing(
-      adjudicationNumber, hearingId, hearingRequest.locationId, hearingRequest.dateTimeOfHearing, hearingRequest.oicHearingType,
+      adjudicationNumber = adjudicationNumber,
+      locationId = hearingRequest.locationId,
+      dateTimeOfHearing = hearingRequest.dateTimeOfHearing,
+      oicHearingType = hearingRequest.oicHearingType,
     )
 
     return ReportedAdjudicationResponse(reportedAdjudication)
   }
 
-  @DeleteMapping(value = ["/{adjudicationNumber}/hearing/{hearingId}"])
-  @Operation(summary = "deletes a hearing")
+  @DeleteMapping(value = ["/{adjudicationNumber}/hearing"])
+  @Operation(summary = "deletes latest hearing")
   @ResponseStatus(HttpStatus.OK)
   fun deleteHearing(
     @PathVariable(name = "adjudicationNumber") adjudicationNumber: Long,
-    @PathVariable(name = "hearingId") hearingId: Long,
   ): ReportedAdjudicationResponse {
-    val reportedAdjudication = hearingService.deleteHearing(
-      adjudicationNumber, hearingId
-    )
+    val reportedAdjudication = hearingService.deleteHearing(adjudicationNumber = adjudicationNumber)
     return ReportedAdjudicationResponse(reportedAdjudication)
   }
 
@@ -115,26 +117,24 @@ class HearingController(
     @PathVariable(name = "agencyId") agencyId: String,
     @RequestParam(name = "hearingDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) hearingDate: LocalDate,
   ): HearingSummaryResponse {
-    val hearings = hearingService.getAllHearingsByAgencyIdAndDate(agencyId, hearingDate)
+    val hearings = hearingService.getAllHearingsByAgencyIdAndDate(agencyId = agencyId, dateOfHearing = hearingDate)
 
     return HearingSummaryResponse(
       hearings
     )
   }
 
-  @Operation(summary = "create a hearing outcome")
-  @PostMapping(value = ["/{adjudicationNumber}/hearing/{hearingId}/outcome"])
+  @Operation(summary = "create a hearing outcome for latest hearing")
+  @PostMapping(value = ["/{adjudicationNumber}/hearing/outcome"])
   @ResponseStatus(HttpStatus.CREATED)
   fun createHearingOutcome(
     @PathVariable(name = "adjudicationNumber") adjudicationNumber: Long,
-    @PathVariable(name = "hearingId") hearingId: Long,
     @RequestBody hearingOutcomeRequest: HearingOutcomeRequest
   ): ReportedAdjudicationResponse {
     val reportedAdjudication =
       when (hearingOutcomeRequest.code.outcomeCode) {
         null -> hearingOutcomeService.createHearingOutcome(
           adjudicationNumber = adjudicationNumber,
-          hearingId = hearingId,
           adjudicator = hearingOutcomeRequest.adjudicator,
           code = hearingOutcomeRequest.code,
           reason = hearingOutcomeRequest.reason,
@@ -144,7 +144,6 @@ class HearingController(
         )
         else -> referralService.createReferral(
           adjudicationNumber = adjudicationNumber,
-          hearingId = hearingId,
           code = hearingOutcomeRequest.code,
           adjudicator = hearingOutcomeRequest.adjudicator,
           details = hearingOutcomeRequest.details!!
@@ -154,19 +153,17 @@ class HearingController(
     return ReportedAdjudicationResponse(reportedAdjudication)
   }
 
-  @Operation(summary = "update a hearing outcome")
-  @PutMapping(value = ["/{adjudicationNumber}/hearing/{hearingId}/outcome"])
+  @Operation(summary = "update a hearing outcome for latest hearing")
+  @PutMapping(value = ["/{adjudicationNumber}/hearing/outcome"])
   @ResponseStatus(HttpStatus.OK)
   fun updateHearingOutcome(
     @PathVariable(name = "adjudicationNumber") adjudicationNumber: Long,
-    @PathVariable(name = "hearingId") hearingId: Long,
     @RequestBody hearingOutcomeRequest: HearingOutcomeRequest
   ): ReportedAdjudicationResponse {
     val reportedAdjudication =
       when (hearingOutcomeRequest.code.outcomeCode) {
         null -> hearingOutcomeService.updateHearingOutcome(
           adjudicationNumber = adjudicationNumber,
-          hearingId = hearingId,
           code = hearingOutcomeRequest.code,
           adjudicator = hearingOutcomeRequest.adjudicator,
           reason = hearingOutcomeRequest.reason,
@@ -176,7 +173,6 @@ class HearingController(
         )
         else -> referralService.updateReferral(
           adjudicationNumber = adjudicationNumber,
-          hearingId = hearingId,
           code = hearingOutcomeRequest.code,
           adjudicator = hearingOutcomeRequest.adjudicator,
           details = hearingOutcomeRequest.details!!

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeService.kt
@@ -132,12 +132,10 @@ class HearingOutcomeService(
       return this
     }
 
+    fun ReportedAdjudication.getHearingOutcome() = this.getHearing().hearingOutcome.hearingOutcomeExists()
+
+    fun HearingOutcome?.hearingOutcomeExists() = this ?: throw EntityNotFoundException("outcome not found for hearing")
+
     private fun validateField(field: Any?) = field ?: throw ValidationException("missing mandatory field")
-
-    fun ReportedAdjudication.getHearingOutcome() =
-      this.getHearing().hearingOutcome.hearingOutcomeExists()
-
-    fun HearingOutcome?.hearingOutcomeExists() =
-      this ?: throw EntityNotFoundException("outcome not found for hearing")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeService.kt
@@ -31,7 +31,6 @@ class HearingOutcomeService(
 
   fun createHearingOutcome(
     adjudicationNumber: Long,
-    hearingId: Long,
     code: HearingOutcomeCode,
     adjudicator: String,
     reason: HearingOutcomeAdjournReason? = null,
@@ -40,7 +39,7 @@ class HearingOutcomeService(
     plea: HearingOutcomePlea? = null
   ): ReportedAdjudicationDto {
     val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber)
-    val hearingToAddOutcomeTo = reportedAdjudication.getHearing(hearingId)
+    val hearingToAddOutcomeTo = reportedAdjudication.getHearing()
     val hearingOutcome = HearingOutcome(
       code = code,
       reason = reason,
@@ -57,7 +56,6 @@ class HearingOutcomeService(
 
   fun updateHearingOutcome(
     adjudicationNumber: Long,
-    hearingId: Long,
     code: HearingOutcomeCode,
     adjudicator: String,
     reason: HearingOutcomeAdjournReason? = null,
@@ -66,7 +64,7 @@ class HearingOutcomeService(
     plea: HearingOutcomePlea? = null
   ): ReportedAdjudicationDto {
     val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber)
-    val outcomeToAmend = reportedAdjudication.getHearingOutcome(hearingId)
+    val outcomeToAmend = reportedAdjudication.getHearingOutcome()
 
     outcomeToAmend.code = code
     outcomeToAmend.adjudicator = adjudicator
@@ -99,9 +97,9 @@ class HearingOutcomeService(
 
   fun deleteHearingOutcome(adjudicationNumber: Long, hearingId: Long): ReportedAdjudicationDto {
     val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber)
-    val outcomeToRemove = reportedAdjudication.getHearing(hearingId)
+    val outcomeToRemove = reportedAdjudication.getHearing()
 
-    outcomeToRemove.hearingOutcome.hearingOutcomeExists(hearingId)
+    outcomeToRemove.hearingOutcome.hearingOutcomeExists()
     outcomeToRemove.hearingOutcome = null
 
     return saveToDto(reportedAdjudication)
@@ -136,10 +134,10 @@ class HearingOutcomeService(
 
     private fun validateField(field: Any?) = field ?: throw ValidationException("missing mandatory field")
 
-    fun ReportedAdjudication.getHearingOutcome(hearingId: Long) =
-      this.getHearing(hearingId).hearingOutcome.hearingOutcomeExists(hearingId)
+    fun ReportedAdjudication.getHearingOutcome() =
+      this.getHearing().hearingOutcome.hearingOutcomeExists()
 
-    fun HearingOutcome?.hearingOutcomeExists(hearingId: Long) =
-      this ?: throw EntityNotFoundException("outcome not found for hearing $hearingId")
+    fun HearingOutcome?.hearingOutcomeExists() =
+      this ?: throw EntityNotFoundException("outcome not found for hearing")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingService.kt
@@ -153,18 +153,18 @@ class HearingService(
       latestHearing.hearingOutcome ?: throw ValidationException("Adjudication already has a hearing without outcome")
       return this
     }
+
     fun List<Hearing>.validateHearingDate(date: LocalDateTime) {
       if (this.any { it.dateTimeOfHearing.isAfter(date) })
         throw ValidationException("A hearing can not be before the previous hearing")
     }
-    private fun ReportedAdjudication.getLatestHearing(): Hearing? =
-      this.hearings.maxByOrNull { it.dateTimeOfHearing }
-    fun ReportedAdjudication.getHearing(): Hearing =
-      this.getLatestHearing() ?: throwHearingNotFoundException()
-    private fun throwHearingNotFoundException(): Nothing =
-      throw EntityNotFoundException("Hearing not found")
 
-    fun ReportedAdjudication.calcFirstHearingDate(): LocalDateTime? =
-      this.hearings.minOfOrNull { it.dateTimeOfHearing }
+    fun ReportedAdjudication.getHearing(): Hearing = this.getLatestHearing() ?: throwHearingNotFoundException()
+
+    fun ReportedAdjudication.calcFirstHearingDate(): LocalDateTime? = this.hearings.minOfOrNull { it.dateTimeOfHearing }
+
+    private fun throwHearingNotFoundException(): Nothing = throw EntityNotFoundException("Hearing not found")
+
+    private fun ReportedAdjudication.getLatestHearing(): Hearing? = this.hearings.maxByOrNull { it.dateTimeOfHearing }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingService.kt
@@ -14,10 +14,12 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.Hea
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.OffenceCodeLookupService
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.HearingService.Companion.getHearing
 import java.time.LocalDate
 import java.time.LocalDateTime
 import javax.persistence.EntityNotFoundException
 import javax.transaction.Transactional
+import javax.validation.ValidationException
 
 @Transactional
 @Service
@@ -37,7 +39,8 @@ class HearingService(
     val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber).also {
       oicHearingType.isValidState(it.isYouthOffender)
       it.status.validateTransition(ReportedAdjudicationStatus.SCHEDULED)
-    }
+      it.hearings.validateHearingDate(dateTimeOfHearing)
+    }.validateCanCreate()
 
     val oicHearingId = prisonApiGateway.createHearing(
       adjudicationNumber = adjudicationNumber,
@@ -68,13 +71,14 @@ class HearingService(
     return saveToDto(reportedAdjudication)
   }
 
-  fun amendHearing(adjudicationNumber: Long, hearingId: Long, locationId: Long, dateTimeOfHearing: LocalDateTime, oicHearingType: OicHearingType): ReportedAdjudicationDto {
+  fun amendHearing(adjudicationNumber: Long, locationId: Long, dateTimeOfHearing: LocalDateTime, oicHearingType: OicHearingType): ReportedAdjudicationDto {
     val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber).also {
       oicHearingType.isValidState(it.isYouthOffender)
       it.status.validateTransition(ReportedAdjudicationStatus.SCHEDULED, ReportedAdjudicationStatus.UNSCHEDULED)
     }
 
-    val hearingToEdit = reportedAdjudication.getHearing(hearingId)
+    val hearingToEdit = reportedAdjudication.getHearing()
+    reportedAdjudication.hearings.filter { it.id != hearingToEdit.id }.validateHearingDate(dateTimeOfHearing)
 
     prisonApiGateway.amendHearing(
       adjudicationNumber = adjudicationNumber,
@@ -97,9 +101,9 @@ class HearingService(
     return saveToDto(reportedAdjudication)
   }
 
-  fun deleteHearing(adjudicationNumber: Long, hearingId: Long): ReportedAdjudicationDto {
+  fun deleteHearing(adjudicationNumber: Long): ReportedAdjudicationDto {
     val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber)
-    val hearingToRemove = reportedAdjudication.getHearing(hearingId)
+    val hearingToRemove = reportedAdjudication.getHearing()
 
     prisonApiGateway.deleteHearing(
       adjudicationNumber = adjudicationNumber,
@@ -144,10 +148,21 @@ class HearingService(
 
   companion object {
 
-    fun ReportedAdjudication.getHearing(hearingId: Long) =
-      this.hearings.find { it.id!! == hearingId } ?: throwHearingNotFoundException(hearingId)
-    private fun throwHearingNotFoundException(id: Long): Nothing =
-      throw EntityNotFoundException("Hearing not found for $id")
+    fun ReportedAdjudication.validateCanCreate(): ReportedAdjudication {
+      val latestHearing = this.getLatestHearing() ?: return this
+      latestHearing.hearingOutcome ?: throw ValidationException("Adjudication already has a hearing without outcome")
+      return this
+    }
+    fun List<Hearing>.validateHearingDate(date: LocalDateTime) {
+      if (this.any { it.dateTimeOfHearing.isAfter(date) })
+        throw ValidationException("A hearing can not be before the previous hearing")
+    }
+    private fun ReportedAdjudication.getLatestHearing(): Hearing? =
+      this.hearings.maxByOrNull { it.dateTimeOfHearing }
+    fun ReportedAdjudication.getHearing(): Hearing =
+      this.getLatestHearing() ?: throwHearingNotFoundException()
+    private fun throwHearingNotFoundException(): Nothing =
+      throw EntityNotFoundException("Hearing not found")
 
     fun ReportedAdjudication.calcFirstHearingDate(): LocalDateTime? =
       this.hearings.minOfOrNull { it.dateTimeOfHearing }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralService.kt
@@ -17,14 +17,12 @@ class ReferralService(
 
   fun createReferral(
     adjudicationNumber: Long,
-    hearingId: Long,
     code: HearingOutcomeCode,
     adjudicator: String,
     details: String,
   ): ReportedAdjudicationDto {
     hearingOutcomeService.createHearingOutcome(
       adjudicationNumber = adjudicationNumber,
-      hearingId = hearingId,
       code = code,
       adjudicator = adjudicator,
       details = details,
@@ -38,14 +36,12 @@ class ReferralService(
 
   fun updateReferral(
     adjudicationNumber: Long,
-    hearingId: Long,
     code: HearingOutcomeCode,
     adjudicator: String,
     details: String,
   ): ReportedAdjudicationDto {
     return hearingOutcomeService.updateHearingOutcome(
       adjudicationNumber = adjudicationNumber,
-      hearingId = hearingId,
       code = code,
       adjudicator = adjudicator,
       details = details,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingControllerTest.kt
@@ -108,43 +108,41 @@ class HearingControllerTest : TestControllerBase() {
       whenever(
         hearingService.deleteHearing(
           ArgumentMatchers.anyLong(),
-          ArgumentMatchers.anyLong(),
         )
       ).thenReturn(REPORTED_ADJUDICATION_DTO)
     }
 
     @Test
     fun `responds with a unauthorised status code`() {
-      deleteHearingRequest(1, 1).andExpect(MockMvcResultMatchers.status().isUnauthorized)
+      deleteHearingRequest(1,).andExpect(MockMvcResultMatchers.status().isUnauthorized)
     }
 
     @Test
     @WithMockUser(username = "ITAG_USER", authorities = ["SCOPE_write"])
     fun `responds with a forbidden status code for non ALO`() {
-      deleteHearingRequest(1, 1).andExpect(MockMvcResultMatchers.status().isForbidden)
+      deleteHearingRequest(1,).andExpect(MockMvcResultMatchers.status().isForbidden)
     }
 
     @Test
     @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER"])
     fun `responds with a forbidden status code for ALO without write scope`() {
-      deleteHearingRequest(1, 1).andExpect(MockMvcResultMatchers.status().isForbidden)
+      deleteHearingRequest(1,).andExpect(MockMvcResultMatchers.status().isForbidden)
     }
 
     @Test
     @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER", "SCOPE_write"])
     fun `makes a call to delete a hearing`() {
-      deleteHearingRequest(1, 1)
+      deleteHearingRequest(1,)
         .andExpect(MockMvcResultMatchers.status().isOk)
-      verify(hearingService).deleteHearing(1, 1)
+      verify(hearingService).deleteHearing(1,)
     }
 
     private fun deleteHearingRequest(
       id: Long,
-      hearingId: Long
     ): ResultActions {
       return mockMvc
         .perform(
-          MockMvcRequestBuilders.delete("/reported-adjudications/$id/hearing/$hearingId")
+          MockMvcRequestBuilders.delete("/reported-adjudications/$id/hearing")
             .header("Content-Type", "application/json")
         )
     }
@@ -158,7 +156,6 @@ class HearingControllerTest : TestControllerBase() {
         hearingService.amendHearing(
           ArgumentMatchers.anyLong(),
           ArgumentMatchers.anyLong(),
-          ArgumentMatchers.anyLong(),
           any(),
           any(),
         )
@@ -168,7 +165,7 @@ class HearingControllerTest : TestControllerBase() {
     @Test
     fun `responds with a unauthorised status code`() {
       amendHearingRequest(
-        1, 1,
+        1,
         HEARING_REQUEST
       ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
     }
@@ -177,7 +174,7 @@ class HearingControllerTest : TestControllerBase() {
     @WithMockUser(username = "ITAG_USER", authorities = ["SCOPE_write"])
     fun `responds with a forbidden status code for non ALO`() {
       amendHearingRequest(
-        1, 1,
+        1,
         HEARING_REQUEST
       ).andExpect(MockMvcResultMatchers.status().isForbidden)
     }
@@ -186,7 +183,7 @@ class HearingControllerTest : TestControllerBase() {
     @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER"])
     fun `responds with a forbidden status code for ALO without write scope`() {
       amendHearingRequest(
-        1, 1,
+        1,
         HEARING_REQUEST
       ).andExpect(MockMvcResultMatchers.status().isForbidden)
     }
@@ -194,20 +191,19 @@ class HearingControllerTest : TestControllerBase() {
     @Test
     @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER", "SCOPE_write"])
     fun `makes a call to amend a hearing`() {
-      amendHearingRequest(1, 1, HEARING_REQUEST)
+      amendHearingRequest(1, HEARING_REQUEST)
         .andExpect(MockMvcResultMatchers.status().isOk)
-      verify(hearingService).amendHearing(1, 1, HEARING_REQUEST.locationId, HEARING_REQUEST.dateTimeOfHearing, HEARING_REQUEST.oicHearingType)
+      verify(hearingService).amendHearing(1, HEARING_REQUEST.locationId, HEARING_REQUEST.dateTimeOfHearing, HEARING_REQUEST.oicHearingType)
     }
 
     private fun amendHearingRequest(
       id: Long,
-      hearingId: Long,
       hearing: HearingRequest?
     ): ResultActions {
       val body = objectMapper.writeValueAsString(hearing)
       return mockMvc
         .perform(
-          MockMvcRequestBuilders.put("/reported-adjudications/$id/hearing/$hearingId")
+          MockMvcRequestBuilders.put("/reported-adjudications/$id/hearing")
             .header("Content-Type", "application/json")
             .content(body)
         )
@@ -267,7 +263,6 @@ class HearingControllerTest : TestControllerBase() {
       whenever(
         hearingOutcomeService.createHearingOutcome(
           ArgumentMatchers.anyLong(),
-          ArgumentMatchers.anyLong(),
           any(),
           any(),
           anyOrNull(),
@@ -280,7 +275,6 @@ class HearingControllerTest : TestControllerBase() {
       whenever(
         referralService.createReferral(
           ArgumentMatchers.anyLong(),
-          ArgumentMatchers.anyLong(),
           any(),
           any(),
           any(),
@@ -292,7 +286,7 @@ class HearingControllerTest : TestControllerBase() {
     fun `responds with a unauthorised status code`() {
       createHearingOutcomeRequest(
         1,
-        1,
+
         hearingOutcomeRequest()
       ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
     }
@@ -302,7 +296,7 @@ class HearingControllerTest : TestControllerBase() {
     fun `responds with a forbidden status code for non ALO`() {
       createHearingOutcomeRequest(
         1,
-        1,
+
         hearingOutcomeRequest()
       ).andExpect(MockMvcResultMatchers.status().isForbidden)
     }
@@ -311,18 +305,16 @@ class HearingControllerTest : TestControllerBase() {
     @CsvSource("REFER_POLICE", "REFER_INAD", "COMPLETE", "ADJOURN")
     @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER", "SCOPE_write"])
     fun `makes a call to create a hearing outcome`(code: HearingOutcomeCode) {
-      createHearingOutcomeRequest(1, 1, hearingOutcomeRequest(code))
+      createHearingOutcomeRequest(1, hearingOutcomeRequest(code))
         .andExpect(MockMvcResultMatchers.status().isCreated)
       if (code.outcomeCode != null) verify(referralService).createReferral(
         adjudicationNumber = 1,
-        hearingId = 1,
         code = code,
         adjudicator = "test",
         details = "details"
       )
       else verify(hearingOutcomeService).createHearingOutcome(
         adjudicationNumber = 1,
-        hearingId = 1,
         code = code,
         adjudicator = "test",
         reason = null,
@@ -332,13 +324,12 @@ class HearingControllerTest : TestControllerBase() {
 
     private fun createHearingOutcomeRequest(
       id: Long,
-      hearingId: Long,
       hearingOutcome: HearingOutcomeRequest?
     ): ResultActions {
       val body = objectMapper.writeValueAsString(hearingOutcome)
       return mockMvc
         .perform(
-          MockMvcRequestBuilders.post("/reported-adjudications/$id/hearing/$hearingId/outcome")
+          MockMvcRequestBuilders.post("/reported-adjudications/$id/hearing/outcome")
             .header("Content-Type", "application/json")
             .content(body)
         )
@@ -352,7 +343,6 @@ class HearingControllerTest : TestControllerBase() {
       whenever(
         hearingOutcomeService.updateHearingOutcome(
           ArgumentMatchers.anyLong(),
-          ArgumentMatchers.anyLong(),
           any(),
           any(),
           anyOrNull(),
@@ -365,7 +355,6 @@ class HearingControllerTest : TestControllerBase() {
       whenever(
         referralService.updateReferral(
           ArgumentMatchers.anyLong(),
-          ArgumentMatchers.anyLong(),
           any(),
           any(),
           any(),
@@ -377,7 +366,6 @@ class HearingControllerTest : TestControllerBase() {
     fun `responds with a unauthorised status code`() {
       updateHearingOutcomeRequest(
         1,
-        1,
         hearingOutcomeRequest()
       ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
     }
@@ -387,7 +375,6 @@ class HearingControllerTest : TestControllerBase() {
     fun `responds with a forbidden status code for non ALO`() {
       updateHearingOutcomeRequest(
         1,
-        1,
         hearingOutcomeRequest()
       ).andExpect(MockMvcResultMatchers.status().isForbidden)
     }
@@ -396,18 +383,16 @@ class HearingControllerTest : TestControllerBase() {
     @CsvSource("REFER_POLICE", "REFER_INAD", "COMPLETE", "ADJOURN")
     @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER", "SCOPE_write"])
     fun `makes a call to update a hearing outcome`(code: HearingOutcomeCode) {
-      updateHearingOutcomeRequest(1, 1, hearingOutcomeRequest(code))
+      updateHearingOutcomeRequest(1, hearingOutcomeRequest(code))
         .andExpect(MockMvcResultMatchers.status().isOk)
       if (code.outcomeCode != null) verify(referralService).updateReferral(
         adjudicationNumber = 1,
-        hearingId = 1,
         code = code,
         adjudicator = "test",
         details = "details"
       )
       else verify(hearingOutcomeService).updateHearingOutcome(
         adjudicationNumber = 1,
-        hearingId = 1,
         code = code,
         adjudicator = "test",
         details = "details"
@@ -416,13 +401,12 @@ class HearingControllerTest : TestControllerBase() {
 
     private fun updateHearingOutcomeRequest(
       id: Long,
-      hearingId: Long,
       hearingOutcome: HearingOutcomeRequest?
     ): ResultActions {
       val body = objectMapper.writeValueAsString(hearingOutcome)
       return mockMvc
         .perform(
-          MockMvcRequestBuilders.put("/reported-adjudications/$id/hearing/$hearingId/outcome")
+          MockMvcRequestBuilders.put("/reported-adjudications/$id/hearing/outcome")
             .header("Content-Type", "application/json")
             .content(body)
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
@@ -103,13 +103,13 @@ class HearingsIntTest : IntegrationTestBase() {
   @Test
   fun `amend a hearing `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    val reportedAdjudication = initDataForHearings().createHearing()
+    initDataForHearings().createHearing()
 
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 25, 10, 0)
 
     webTestClient.put()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/${reportedAdjudication.reportedAdjudication.hearings.first().id}")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
@@ -134,13 +134,13 @@ class HearingsIntTest : IntegrationTestBase() {
   @Test
   fun `amend a hearing illegal state on hearing type `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    val reportedAdjudication = initDataForHearings().createHearing()
+    initDataForHearings().createHearing()
 
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 25, 10, 0)
 
     webTestClient.put()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/${reportedAdjudication.reportedAdjudication.hearings.first().id}")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
@@ -156,13 +156,13 @@ class HearingsIntTest : IntegrationTestBase() {
   @Test
   fun `amend a hearing fails on prison api and does not update the hearing `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    val reportedAdjudication = initDataForHearings().createHearing()
+    initDataForHearings().createHearing()
 
     prisonApiMockServer.stubAmendHearingFailure(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 25, 10, 0)
 
     webTestClient.put()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/${reportedAdjudication.reportedAdjudication.hearings.first().id}")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
@@ -190,14 +190,11 @@ class HearingsIntTest : IntegrationTestBase() {
   @Test
   fun `delete a hearing `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    val reportedAdjudication = initDataForHearings().createHearing()
-
+    initDataForHearings().createHearing()
     prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
 
-    assert(reportedAdjudication.reportedAdjudication.hearings.size == 1)
-
     webTestClient.delete()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/${reportedAdjudication.reportedAdjudication.hearings.first().id!!}")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .exchange()
       .expectStatus().isOk
@@ -210,14 +207,12 @@ class HearingsIntTest : IntegrationTestBase() {
   @Test
   fun `delete a hearing fails on prison api and does not delete record`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    val reportedAdjudication = initDataForHearings().createHearing()
+    initDataForHearings().createHearing()
 
     prisonApiMockServer.stubDeleteHearingFailure(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
 
-    assert(reportedAdjudication.reportedAdjudication.hearings.size == 1)
-
     webTestClient.delete()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/${reportedAdjudication.reportedAdjudication.hearings.first().id!!}")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .exchange()
       .expectStatus().is5xxServerError
@@ -234,10 +229,10 @@ class HearingsIntTest : IntegrationTestBase() {
   @Test
   fun `create hearing outcome`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    val reportedAdjudication = initDataForHearings().createHearing()
+    initDataForHearings().createHearing()
 
     webTestClient.post()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/${reportedAdjudication.reportedAdjudication.hearings.first().id}/outcome")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/outcome")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
@@ -269,10 +264,10 @@ class HearingsIntTest : IntegrationTestBase() {
   @Test
   fun `create hearing outcome for referral`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    val reportedAdjudication = initDataForHearings().createHearing()
+    initDataForHearings().createHearing()
 
     webTestClient.post()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/${reportedAdjudication.reportedAdjudication.hearings.first().id}/outcome")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/outcome")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
@@ -302,13 +297,10 @@ class HearingsIntTest : IntegrationTestBase() {
   @Test
   fun `update hearing outcome`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    var reportedAdjudication = initDataForHearings().createHearing()
-    reportedAdjudication = integrationTestData().createHearingOutcome(
-      reportedAdjudication.reportedAdjudication.adjudicationNumber, reportedAdjudication.reportedAdjudication.hearings.first().id!!
-    )
+    initDataForHearings().createHearing().createHearingOutcome()
 
     webTestClient.put()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/${reportedAdjudication.reportedAdjudication.hearings.first().id}/outcome")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/outcome")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
@@ -337,13 +329,10 @@ class HearingsIntTest : IntegrationTestBase() {
   @Disabled // currently not implemented fully so status will not update
   fun `update hearing outcome to a referral`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    var reportedAdjudication = initDataForHearings().createHearing()
-    reportedAdjudication = integrationTestData().createHearingOutcome(
-      reportedAdjudication.reportedAdjudication.adjudicationNumber, reportedAdjudication.reportedAdjudication.hearings.first().id!!
-    )
+    initDataForHearings().createHearing().createHearingOutcome()
 
     webTestClient.put()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/${reportedAdjudication.reportedAdjudication.hearings.first().id}/outcome")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/outcome")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
@@ -372,7 +361,7 @@ class HearingsIntTest : IntegrationTestBase() {
   @Test
   fun `referral transaction is rolled back when hearing outcome succeeds and outcome creation fails`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    val reportedAdjudication = initDataForHearings().createHearing()
+    initDataForHearings().createHearing()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/status")
@@ -388,7 +377,7 @@ class HearingsIntTest : IntegrationTestBase() {
       .expectStatus().is2xxSuccessful
 
     webTestClient.post()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/${reportedAdjudication.reportedAdjudication.hearings.first().id}/outcome")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/outcome")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
@@ -413,26 +402,22 @@ class HearingsIntTest : IntegrationTestBase() {
   @Test
   fun `get all hearings`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    val reportedAdjudication = initDataForHearings().createHearing()
+    initDataForHearings().createHearing()
 
     webTestClient.get()
-      .uri("/reported-adjudications/hearings/agency/${IntegrationTestData.DEFAULT_ADJUDICATION.agencyId}?hearingDate=${reportedAdjudication.reportedAdjudication.hearings.first().dateTimeOfHearing.toLocalDate()}")
+      .uri("/reported-adjudications/hearings/agency/${IntegrationTestData.DEFAULT_ADJUDICATION.agencyId}?hearingDate=${IntegrationTestData.DEFAULT_ADJUDICATION.dateTimeOfHearing!!.toLocalDate()}")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .exchange()
       .expectStatus().isOk
       .expectBody()
       .jsonPath("$.hearings.size()").isEqualTo(1)
-      .jsonPath("$.hearings[0].id")
-      .isEqualTo(reportedAdjudication.reportedAdjudication.hearings.first().id!!)
       .jsonPath("$.hearings[0].prisonerNumber")
-      .isEqualTo(reportedAdjudication.reportedAdjudication.prisonerNumber)
+      .isEqualTo(IntegrationTestData.DEFAULT_ADJUDICATION.prisonerNumber)
       .jsonPath("$.hearings[0].adjudicationNumber")
-      .isEqualTo(reportedAdjudication.reportedAdjudication.adjudicationNumber)
+      .isEqualTo(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
       .jsonPath("$.hearings[0].dateTimeOfDiscovery")
       .isEqualTo(IntegrationTestData.DEFAULT_ADJUDICATION.dateTimeOfDiscoveryISOString)
       .jsonPath("$.hearings[0].dateTimeOfHearing")
       .isEqualTo(IntegrationTestData.DEFAULT_ADJUDICATION.dateTimeOfHearingISOString)
-      .jsonPath("$.hearings[0].oicHearingType")
-      .isEqualTo(reportedAdjudication.reportedAdjudication.hearings.first().oicHearingType.name)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
@@ -533,11 +533,11 @@ class IntegrationTestData(
   }
 
   fun createOutcome(
-    reportNumber: String,
+    testDataSet: AdjudicationIntTestDataSet,
     code: OutcomeCode? = OutcomeCode.REFER_POLICE
   ): WebTestClient.ResponseSpec {
     return webTestClient.post()
-      .uri("/reported-adjudications/$reportNumber/outcome")
+      .uri("/reported-adjudications/${testDataSet.adjudicationNumber}/outcome")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
@@ -550,30 +550,27 @@ class IntegrationTestData(
 
   fun createHearing(
     testDataSet: AdjudicationIntTestDataSet,
-  ): ReportedAdjudicationResponse {
+    dateTimeOfHearing: LocalDateTime? = null
+  ): WebTestClient.ResponseSpec {
     return webTestClient.post()
       .uri("/reported-adjudications/${testDataSet.adjudicationNumber}/hearing")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
           "locationId" to testDataSet.locationId,
-          "dateTimeOfHearing" to testDataSet.dateTimeOfHearing!!,
+          "dateTimeOfHearing" to (dateTimeOfHearing ?: testDataSet.dateTimeOfHearing!!),
           "oicHearingType" to OicHearingType.GOV.name,
         )
       )
       .exchange()
-      .returnResult(ReportedAdjudicationResponse::class.java)
-      .responseBody
-      .blockFirst()!!
   }
 
   fun createHearingOutcome(
-    adjudicationNumber: Long,
-    hearingId: Long,
+    testDataSet: AdjudicationIntTestDataSet,
     code: HearingOutcomeCode? = HearingOutcomeCode.ADJOURN
   ): ReportedAdjudicationResponse {
     return webTestClient.post()
-      .uri("/reported-adjudications/$adjudicationNumber/hearing/$hearingId/outcome")
+      .uri("/reported-adjudications/${testDataSet.adjudicationNumber}/hearing/outcome")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestScenarioBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestScenarioBuilder.kt
@@ -3,7 +3,8 @@ package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration
 import org.springframework.http.HttpHeaders
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.draft.DraftAdjudicationResponse
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.reported.ReportedAdjudicationResponse
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 
 class IntegrationTestScenarioBuilder(
@@ -79,16 +80,27 @@ class IntegrationTestScenario(
     return this
   }
 
-  fun createHearing(): ReportedAdjudicationResponse {
-    return intTestData.createHearing(
+  fun createHearing(): IntegrationTestScenario {
+    intTestData.createHearing(
       testAdjudicationDataSet,
     )
+    return this
   }
 
-  fun createOutcome(reportNumber: String): IntegrationTestScenario {
-    intTestData.createOutcome(reportNumber)
-
+  fun createHearingOutcome(
+    code: HearingOutcomeCode? = HearingOutcomeCode.ADJOURN
+  ): IntegrationTestScenario {
+    intTestData.createHearingOutcome(
+      testAdjudicationDataSet,
+      code
+    )
     return this
+  }
+
+  fun createOutcome(
+    code: OutcomeCode? = OutcomeCode.REFER_POLICE
+  ): WebTestClient.ResponseSpec {
+    return intTestData.createOutcome(testAdjudicationDataSet, code)
   }
 
   fun issueReport(reportNumber: String): IntegrationTestScenario {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReferralsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReferralsIntTest.kt
@@ -9,10 +9,7 @@ class ReferralsIntTest : OutcomeIntTest() {
   @Test
   fun `remove referral with hearing`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    val reportedAdjudication = initDataForHearings().createHearing()
-    integrationTestData().createHearingOutcome(
-      reportedAdjudication.reportedAdjudication.adjudicationNumber, reportedAdjudication.reportedAdjudication.hearings.first().id!!, HearingOutcomeCode.REFER_POLICE
-    )
+    initDataForHearings().createHearing().createHearingOutcome(HearingOutcomeCode.REFER_POLICE)
 
     webTestClient.delete()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/remove-referral")
@@ -27,13 +24,8 @@ class ReferralsIntTest : OutcomeIntTest() {
   @Test
   fun `remove referral with hearing and referral outcome`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    val reportedAdjudication = initDataForHearings().createHearing()
-    integrationTestData().createHearingOutcome(
-      reportedAdjudication.reportedAdjudication.adjudicationNumber, reportedAdjudication.reportedAdjudication.hearings.first().id!!, HearingOutcomeCode.REFER_POLICE
-    )
-    integrationTestData().createOutcome(
-      reportedAdjudication.reportedAdjudication.adjudicationNumber.toString(), OutcomeCode.PROSECUTION
-    ).expectStatus().isCreated
+    initDataForHearings().createHearing().createHearingOutcome(HearingOutcomeCode.REFER_POLICE)
+      .createOutcome(OutcomeCode.PROSECUTION).expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
       .jsonPath("$.reportedAdjudication.outcomes[0].referralOutcome").exists()
@@ -51,7 +43,7 @@ class ReferralsIntTest : OutcomeIntTest() {
 
   @Test
   fun `remove referral without hearing`() {
-    initDataForOutcome().createOutcome(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber.toString())
+    initDataForOutcome().createOutcome()
 
     webTestClient.delete()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/remove-referral")
@@ -65,10 +57,10 @@ class ReferralsIntTest : OutcomeIntTest() {
 
   @Test
   fun `remove referral and referral outcome`() {
-    initDataForOutcome().createOutcome(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber.toString())
+    initDataForOutcome().createOutcome()
 
     integrationTestData().createOutcome(
-      IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber.toString(), OutcomeCode.PROSECUTION
+      IntegrationTestData.DEFAULT_ADJUDICATION, OutcomeCode.PROSECUTION
     ).expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
@@ -101,10 +93,10 @@ class ReferralsIntTest : OutcomeIntTest() {
  */
   @Test
   fun `remove referral, referral outcome and hearing outcome for a POLICE_REFER related to complex example`() {
-    initDataForOutcome().createOutcome(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber.toString())
+    initDataForOutcome().createOutcome()
 
     integrationTestData().createOutcome(
-      IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber.toString(), OutcomeCode.SCHEDULE_HEARING
+      IntegrationTestData.DEFAULT_ADJUDICATION, OutcomeCode.SCHEDULE_HEARING
     ).expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
@@ -113,14 +105,14 @@ class ReferralsIntTest : OutcomeIntTest() {
 
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
-    var reportedAdjudication = integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION)
+    integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION)
 
     integrationTestData().createHearingOutcome(
-      reportedAdjudication.reportedAdjudication.adjudicationNumber, reportedAdjudication.reportedAdjudication.hearings.first().id!!, HearingOutcomeCode.REFER_INAD
+      IntegrationTestData.DEFAULT_ADJUDICATION, HearingOutcomeCode.REFER_INAD
     )
 
     integrationTestData().createOutcome(
-      IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber.toString(), OutcomeCode.SCHEDULE_HEARING
+      IntegrationTestData.DEFAULT_ADJUDICATION, OutcomeCode.SCHEDULE_HEARING
     )
       .expectStatus().isCreated
       .expectBody()
@@ -129,14 +121,14 @@ class ReferralsIntTest : OutcomeIntTest() {
       .jsonPath("$.reportedAdjudication.outcomes[1].referralOutcome").exists()
       .jsonPath("$.reportedAdjudication.hearings.size()").isEqualTo(1)
 
-    reportedAdjudication = integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION)
+    integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION, IntegrationTestData.DEFAULT_ADJUDICATION.dateTimeOfHearing!!.plusDays(1))
 
     integrationTestData().createHearingOutcome(
-      reportedAdjudication.reportedAdjudication.adjudicationNumber, reportedAdjudication.reportedAdjudication.hearings.last().id!!, HearingOutcomeCode.REFER_POLICE
+      IntegrationTestData.DEFAULT_ADJUDICATION, HearingOutcomeCode.REFER_POLICE
     )
 
     integrationTestData().createOutcome(
-      IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber.toString(), OutcomeCode.PROSECUTION
+      IntegrationTestData.DEFAULT_ADJUDICATION, OutcomeCode.PROSECUTION
     ).expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(3)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeServiceTest.kt
@@ -36,14 +36,14 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
   override fun `throws an entity not found if the reported adjudication for the supplied id does not exists`() {
     Assertions.assertThatThrownBy {
       hearingOutcomeService.createHearingOutcome(
-        adjudicationNumber = 1, hearingId = 1, adjudicator = "test", code = HearingOutcomeCode.REFER_POLICE
+        adjudicationNumber = 1, adjudicator = "test", code = HearingOutcomeCode.REFER_POLICE
       )
     }.isInstanceOf(EntityNotFoundException::class.java)
       .hasMessageContaining("ReportedAdjudication not found for 1")
 
     Assertions.assertThatThrownBy {
       hearingOutcomeService.updateHearingOutcome(
-        adjudicationNumber = 1, hearingId = 1, code = HearingOutcomeCode.ADJOURN, adjudicator = "test",
+        adjudicationNumber = 1, code = HearingOutcomeCode.ADJOURN, adjudicator = "test",
       )
     }.isInstanceOf(EntityNotFoundException::class.java)
       .hasMessageContaining("ReportedAdjudication not found for 1")
@@ -87,7 +87,7 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
       val argumentCaptor = ArgumentCaptor.forClass(ReportedAdjudication::class.java)
 
       val response = hearingOutcomeService.createHearingOutcome(
-        1, 1, HearingOutcomeCode.REFER_POLICE, "test", HearingOutcomeAdjournReason.LEGAL_ADVICE, "details",
+        1, HearingOutcomeCode.REFER_POLICE, "test", HearingOutcomeAdjournReason.LEGAL_ADVICE, "details",
         HearingOutcomeFinding.NOT_PROCEED_WITH, HearingOutcomePlea.UNFIT
       )
 
@@ -115,9 +115,9 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
       )
 
       Assertions.assertThatThrownBy {
-        hearingOutcomeService.createHearingOutcome(1, 1, HearingOutcomeCode.REFER_POLICE, "testing",)
+        hearingOutcomeService.createHearingOutcome(1, HearingOutcomeCode.REFER_POLICE, "testing",)
       }.isInstanceOf(EntityNotFoundException::class.java)
-        .hasMessageContaining("Hearing not found for 1")
+        .hasMessageContaining("Hearing not found")
     }
 
     @CsvSource("COMPLETE")
@@ -125,7 +125,7 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
     fun `throws invalid state exception if finding not present`(code: HearingOutcomeCode) {
       Assertions.assertThatThrownBy {
         hearingOutcomeService.createHearingOutcome(
-          adjudicationNumber = 1L, hearingId = 1L, adjudicator = "test", code = code, plea = HearingOutcomePlea.UNFIT,
+          adjudicationNumber = 1L, adjudicator = "test", code = code, plea = HearingOutcomePlea.UNFIT,
         )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("missing mandatory field")
@@ -136,7 +136,7 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
     fun `throws invalid state exception if plea is not present`(code: HearingOutcomeCode) {
       Assertions.assertThatThrownBy {
         hearingOutcomeService.createHearingOutcome(
-          adjudicationNumber = 1L, hearingId = 1L, adjudicator = "test", code = code,
+          adjudicationNumber = 1L, adjudicator = "test", code = code,
         )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("missing mandatory field")
@@ -147,7 +147,7 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
     fun `validation details for bad refer request`(code: HearingOutcomeCode) {
       Assertions.assertThatThrownBy {
         hearingOutcomeService.createHearingOutcome(
-          adjudicationNumber = 1L, hearingId = 1L, code = code, adjudicator = "test"
+          adjudicationNumber = 1L, code = code, adjudicator = "test"
         )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("missing mandatory field")
@@ -157,7 +157,7 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
     fun `validation of reason for adjourn`() {
       Assertions.assertThatThrownBy {
         hearingOutcomeService.createHearingOutcome(
-          adjudicationNumber = 1L, hearingId = 1L, code = HearingOutcomeCode.ADJOURN, adjudicator = "test", details = "details", plea = HearingOutcomePlea.ABSTAIN
+          adjudicationNumber = 1L, code = HearingOutcomeCode.ADJOURN, adjudicator = "test", details = "details", plea = HearingOutcomePlea.ABSTAIN
         )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("missing mandatory field")
@@ -232,7 +232,6 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
 
       val response = hearingOutcomeService.updateHearingOutcome(
         adjudicationNumber = 1,
-        hearingId = 1,
         code = code,
         adjudicator = "updated test",
       )
@@ -256,7 +255,6 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
 
       val response = hearingOutcomeService.updateHearingOutcome(
         adjudicationNumber = 1,
-        hearingId = 1,
         code = HearingOutcomeCode.ADJOURN,
         adjudicator = "updated test",
         details = "updated details",
@@ -285,7 +283,6 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
 
       val response = hearingOutcomeService.updateHearingOutcome(
         adjudicationNumber = 1,
-        hearingId = 1,
         code = HearingOutcomeCode.COMPLETE,
         adjudicator = "updated test",
         plea = HearingOutcomePlea.ABSTAIN,
@@ -315,9 +312,9 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
       )
 
       Assertions.assertThatThrownBy {
-        hearingOutcomeService.updateHearingOutcome(1, 1, HearingOutcomeCode.REFER_POLICE, "testing",)
+        hearingOutcomeService.updateHearingOutcome(1, HearingOutcomeCode.REFER_POLICE, "testing",)
       }.isInstanceOf(EntityNotFoundException::class.java)
-        .hasMessageContaining("Hearing not found for 1")
+        .hasMessageContaining("Hearing not found")
     }
 
     @Test
@@ -329,9 +326,9 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
       )
 
       Assertions.assertThatThrownBy {
-        hearingOutcomeService.updateHearingOutcome(1, 1, HearingOutcomeCode.REFER_POLICE, "testing",)
+        hearingOutcomeService.updateHearingOutcome(1, HearingOutcomeCode.REFER_POLICE, "testing",)
       }.isInstanceOf(EntityNotFoundException::class.java)
-        .hasMessageContaining("outcome not found for hearing 1")
+        .hasMessageContaining("outcome not found for hearing")
     }
 
     @CsvSource("COMPLETE")
@@ -339,7 +336,7 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
     fun `throws invalid state exception if finding not present`(code: HearingOutcomeCode) {
       Assertions.assertThatThrownBy {
         hearingOutcomeService.updateHearingOutcome(
-          adjudicationNumber = 1L, hearingId = 1L, code = HearingOutcomeCode.ADJOURN, adjudicator = "test", plea = HearingOutcomePlea.UNFIT,
+          adjudicationNumber = 1L, code = HearingOutcomeCode.ADJOURN, adjudicator = "test", plea = HearingOutcomePlea.UNFIT,
         )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("missing mandatory field")
@@ -350,7 +347,7 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
     fun `throws invalid state exception if plea is not present`(code: HearingOutcomeCode) {
       Assertions.assertThatThrownBy {
         hearingOutcomeService.updateHearingOutcome(
-          adjudicationNumber = 1L, hearingId = 1L, code = HearingOutcomeCode.ADJOURN, adjudicator = "test",
+          adjudicationNumber = 1L, code = HearingOutcomeCode.ADJOURN, adjudicator = "test",
         )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("missing mandatory field")
@@ -361,7 +358,7 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
     fun `validation of details for bad request`(code: HearingOutcomeCode) {
       Assertions.assertThatThrownBy {
         hearingOutcomeService.updateHearingOutcome(
-          adjudicationNumber = 1L, hearingId = 1L, code = code, adjudicator = "test"
+          adjudicationNumber = 1L, code = code, adjudicator = "test"
         )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("missing mandatory field")
@@ -371,7 +368,7 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
     fun `validation of reason for adjourn`() {
       Assertions.assertThatThrownBy {
         hearingOutcomeService.updateHearingOutcome(
-          adjudicationNumber = 1L, hearingId = 1L, code = HearingOutcomeCode.ADJOURN, adjudicator = "test"
+          adjudicationNumber = 1L, code = HearingOutcomeCode.ADJOURN, adjudicator = "test"
         )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("missing mandatory field")
@@ -382,7 +379,6 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
 
       val response = hearingOutcomeService.updateHearingOutcome(
         adjudicationNumber = 1,
-        hearingId = 1,
         code = request.code,
         adjudicator = "updated test",
         reason = request.reason,
@@ -445,7 +441,7 @@ class HearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
       Assertions.assertThatThrownBy {
         hearingOutcomeService.deleteHearingOutcome(1, 1)
       }.isInstanceOf(EntityNotFoundException::class.java)
-        .hasMessageContaining("outcome not found for hearing 1")
+        .hasMessageContaining("outcome not found for hearing")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralServiceTest.kt
@@ -30,11 +30,11 @@ class ReferralServiceTest : ReportedAdjudicationTestBase() {
   fun `create outcome and hearing outcome for referral`() {
 
     referralService.createReferral(
-      1, 1, HearingOutcomeCode.REFER_POLICE, "test", "details",
+      1, HearingOutcomeCode.REFER_POLICE, "test", "details",
     )
 
     verify(hearingOutcomeService, atLeastOnce()).createHearingOutcome(
-      adjudicationNumber = 1, hearingId = 1, code = HearingOutcomeCode.REFER_POLICE, adjudicator = "test", details = "details",
+      adjudicationNumber = 1, code = HearingOutcomeCode.REFER_POLICE, adjudicator = "test", details = "details",
     )
 
     verify(outcomeService, atLeastOnce()).createOutcome(adjudicationNumber = 1, code = OutcomeCode.REFER_POLICE, details = "details")
@@ -44,11 +44,11 @@ class ReferralServiceTest : ReportedAdjudicationTestBase() {
   fun `updates outcome and hearing outcome for referral`() {
 
     referralService.updateReferral(
-      1, 1, HearingOutcomeCode.REFER_INAD, "test 2", "details 2",
+      1, HearingOutcomeCode.REFER_INAD, "test 2", "details 2",
     )
 
     verify(hearingOutcomeService, atLeastOnce()).updateHearingOutcome(
-      adjudicationNumber = 1, hearingId = 1, code = HearingOutcomeCode.REFER_INAD, adjudicator = "test 2", details = "details 2"
+      adjudicationNumber = 1, code = HearingOutcomeCode.REFER_INAD, adjudicator = "test 2", details = "details 2"
     )
 
     // TODO not implemented yet verify(outcomeService, atLeastOnce()).createOutcome(adjudicationNumber = 1, code = OutcomeCode.REFER_POLICE, details = "details 2")


### PR DESCRIPTION
remove hearing id from endpoints, the new design only ever carries out actions on the latest hearing

Simplifies tests (as no longer need to get the id first).

Validation has also been added 

-  Cant add a hearing before a hearing
- Cant amend a hearing to before a hearing
- Cant create a hearing, if there is currently a hearing without an outcome
