### PR TITLE
NN-4851 NN-4845

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/ReportedAdjudicationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/ReportedAdjudicationDto.kt
@@ -61,7 +61,9 @@ data class ReportedAdjudicationDto(
   val dateTimeOfIssue: LocalDateTime? = null,
   @Schema(description = "date time of first hearing")
   val dateTimeOfFirstHearing: LocalDateTime? = null,
-  @Schema(description = "outcome")
+  @Schema(description = "Hearings, hearing outcomes, referrals and outcomes in chronological order")
+  val history: List<OutcomeHistoryDto>,
+  @Schema(description = "outcomes")
   val outcomes: List<CombinedOutcomeDto>,
 )
 
@@ -167,6 +169,14 @@ data class HearingSummaryDto(
   val prisonerNumber: String,
   @Schema(description = "type of hearing")
   val oicHearingType: OicHearingType,
+)
+
+@Schema(description = "item for hearings and referrals table")
+data class OutcomeHistoryDto(
+  @Schema(description = "hearing including hearing outcome")
+  val hearing: HearingDto? = null,
+  @Schema(description = "combined outcome")
+  val outcome: CombinedOutcomeDto? = null,
 )
 
 @Schema(description = "Outcome")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/Outcome.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/Outcome.kt
@@ -22,8 +22,8 @@ enum class OutcomeCode(val status: ReportedAdjudicationStatus) {
   REFER_POLICE(ReportedAdjudicationStatus.REFER_POLICE),
   REFER_INAD(ReportedAdjudicationStatus.REFER_INAD),
   NOT_PROCEED(ReportedAdjudicationStatus.NOT_PROCEED),
-  SCHEDULE_HEARING(ReportedAdjudicationStatus.SCHEDULE_HEARING),
   PROSECUTION(ReportedAdjudicationStatus.PROSECUTION),
+  SCHEDULE_HEARING(ReportedAdjudicationStatus.SCHEDULED),
 }
 
 enum class NotProceedReason {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
@@ -106,20 +106,15 @@ enum class ReportedAdjudicationStatus {
   },
   REFER_POLICE {
     override fun nextStates(): List<ReportedAdjudicationStatus> {
-      return listOf(SCHEDULE_HEARING, PROSECUTION, NOT_PROCEED)
+      return listOf(PROSECUTION, NOT_PROCEED, SCHEDULED)
     }
   },
   REFER_INAD {
     override fun nextStates(): List<ReportedAdjudicationStatus> {
-      return listOf(SCHEDULE_HEARING, NOT_PROCEED)
+      return listOf(NOT_PROCEED, SCHEDULED)
     }
   },
   PROSECUTION,
-  SCHEDULE_HEARING {
-    override fun nextStates(): List<ReportedAdjudicationStatus> {
-      return listOf(SCHEDULED, UNSCHEDULED)
-    }
-  },
   NOT_PROCEED;
   open fun nextStates(): List<ReportedAdjudicationStatus> = listOf()
   fun canTransitionFrom(from: ReportedAdjudicationStatus): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingService.kt
@@ -109,6 +109,9 @@ class HearingService(
     val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber)
     val hearingToRemove = reportedAdjudication.getHearing()
 
+    if (reportedAdjudication.lastOutcomeIsScheduleHearing())
+      reportedAdjudication.outcomes.removeLast()
+
     prisonApiGateway.deleteHearing(
       adjudicationNumber = adjudicationNumber,
       oicHearingId = hearingToRemove.oicHearingId
@@ -162,6 +165,9 @@ class HearingService(
       if (this.any { it.dateTimeOfHearing.isAfter(date) })
         throw ValidationException("A hearing can not be before the previous hearing")
     }
+
+    fun ReportedAdjudication.lastOutcomeIsScheduleHearing() =
+      this.outcomes.maxByOrNull { it.createDateTime!! }?.code == OutcomeCode.SCHEDULE_HEARING
 
     fun ReportedAdjudication.lastOutcomeIsRefer() =
       listOf(OutcomeCode.REFER_INAD, OutcomeCode.REFER_POLICE).contains(this.outcomes.maxByOrNull { it.createDateTime!! }?.code)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -77,7 +77,7 @@ open class ReportedDtoService(
     )
   }
 
-  private fun createHistory(hearings: List<HearingDto>, outcomes: List<CombinedOutcomeDto>): List<OutcomeHistoryDto> {
+  fun createHistory(hearings: List<HearingDto>, outcomes: List<CombinedOutcomeDto>): List<OutcomeHistoryDto> {
     TODO("implement me")
   }
 
@@ -199,6 +199,7 @@ open class ReportedAdjudicationBaseService(
     reportedAdjudicationRepository.findByReportNumber(adjudicationNumber) ?: throwEntityNotFoundException(
       adjudicationNumber
     )
+
   protected fun saveToDto(reportedAdjudication: ReportedAdjudication): ReportedAdjudicationDto =
     reportedAdjudicationRepository.save(reportedAdjudication).toDto()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -36,7 +36,7 @@ open class ReportedDtoService(
 ) {
   protected fun ReportedAdjudication.toDto(): ReportedAdjudicationDto {
     val hearings = this.hearings.toHearings()
-    val outcomes = outcomes.createCombinedOutcomes()
+    val outcomes = this.outcomes.createCombinedOutcomes()
     return ReportedAdjudicationDto(
       adjudicationNumber = reportNumber,
       prisonerNumber = prisonerNumber,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -77,8 +77,16 @@ open class ReportedDtoService(
     )
   }
 
-  fun createHistory(hearings: List<HearingDto>, outcomes: List<CombinedOutcomeDto>): List<OutcomeHistoryDto> {
-    TODO("implement me")
+  private fun createHistory(hearings: List<HearingDto>, outcomes: List<CombinedOutcomeDto>): List<OutcomeHistoryDto> {
+    if (hearings.isEmpty() && outcomes.isEmpty()) return listOf()
+    if (outcomes.isEmpty() && hearings.size == 1) return listOf(OutcomeHistoryDto(hearing = hearings.first()))
+    if (hearings.isEmpty() && outcomes.size == 1) return listOf(OutcomeHistoryDto(outcome = outcomes.first()))
+
+    val history = mutableListOf<OutcomeHistoryDto>()
+    /*
+        outcomes are more important than hearings so should control loop.
+     */
+    return history.toList()
   }
 
   protected fun List<Outcome>.createCombinedOutcomes(): List<CombinedOutcomeDto> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/TestControllerBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/TestControllerBase.kt
@@ -78,6 +78,7 @@ open class TestControllerBase {
         hearings = listOf(),
         gender = Gender.MALE,
         outcomes = listOf(),
+        history = listOf(),
       )
 
     val INCIDENT_ROLE_WITH_ALL_VALUES_RESPONSE_DTO =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
@@ -550,7 +550,8 @@ class IntegrationTestData(
 
   fun createHearing(
     testDataSet: AdjudicationIntTestDataSet,
-    dateTimeOfHearing: LocalDateTime? = null
+    dateTimeOfHearing: LocalDateTime? = null,
+    oicHearingType: OicHearingType? = OicHearingType.GOV
   ): WebTestClient.ResponseSpec {
     return webTestClient.post()
       .uri("/reported-adjudications/${testDataSet.adjudicationNumber}/hearing")
@@ -559,7 +560,7 @@ class IntegrationTestData(
         mapOf(
           "locationId" to testDataSet.locationId,
           "dateTimeOfHearing" to (dateTimeOfHearing ?: testDataSet.dateTimeOfHearing!!),
-          "oicHearingType" to OicHearingType.GOV.name,
+          "oicHearingType" to oicHearingType!!.name,
         )
       )
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Evidenc
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeAdjournReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomePlea
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.NotProceedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.WitnessCode
@@ -534,7 +535,8 @@ class IntegrationTestData(
 
   fun createOutcome(
     testDataSet: AdjudicationIntTestDataSet,
-    code: OutcomeCode? = OutcomeCode.REFER_POLICE
+    code: OutcomeCode? = OutcomeCode.REFER_POLICE,
+    reason: NotProceedReason? = null
   ): WebTestClient.ResponseSpec {
     return webTestClient.post()
       .uri("/reported-adjudications/${testDataSet.adjudicationNumber}/outcome")
@@ -543,6 +545,7 @@ class IntegrationTestData(
         mapOf(
           "code" to code,
           "details" to "details",
+          "reason" to reason
         )
       )
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReferralsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReferralsIntTest.kt
@@ -96,14 +96,6 @@ class ReferralsIntTest : OutcomeIntTest() {
   fun `remove referral, referral outcome and hearing outcome for a POLICE_REFER related to complex example`() {
     initDataForOutcome().createOutcome()
 
-    integrationTestData().createOutcome(
-      IntegrationTestData.DEFAULT_ADJUDICATION, OutcomeCode.SCHEDULE_HEARING
-    ).expectStatus().isCreated
-      .expectBody()
-      .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
-      .jsonPath("$.reportedAdjudication.outcomes[0].referralOutcome").exists()
-      .jsonPath("$.reportedAdjudication.hearings.size()").isEqualTo(0)
-
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
     integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION)
@@ -111,16 +103,6 @@ class ReferralsIntTest : OutcomeIntTest() {
     integrationTestData().createHearingOutcome(
       IntegrationTestData.DEFAULT_ADJUDICATION, HearingOutcomeCode.REFER_INAD
     )
-
-    integrationTestData().createOutcome(
-      IntegrationTestData.DEFAULT_ADJUDICATION, OutcomeCode.SCHEDULE_HEARING
-    )
-      .expectStatus().isCreated
-      .expectBody()
-      .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(2)
-      .jsonPath("$.reportedAdjudication.outcomes[0].referralOutcome").exists()
-      .jsonPath("$.reportedAdjudication.outcomes[1].referralOutcome").exists()
-      .jsonPath("$.reportedAdjudication.hearings.size()").isEqualTo(1)
 
     integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION, IntegrationTestData.DEFAULT_ADJUDICATION.dateTimeOfHearing!!.plusDays(1))
 
@@ -152,7 +134,7 @@ class ReferralsIntTest : OutcomeIntTest() {
       .jsonPath("$.reportedAdjudication.outcomes[0].referralOutcome.code").isEqualTo(OutcomeCode.SCHEDULE_HEARING.name)
       .jsonPath("$.reportedAdjudication.outcomes[1].outcome.code").isEqualTo(OutcomeCode.REFER_INAD.name)
       .jsonPath("$.reportedAdjudication.outcomes[1].referralOutcome.code").isEqualTo(OutcomeCode.SCHEDULE_HEARING.name)
-      .jsonPath("$.reportedAdjudication.status").isEqualTo(ReportedAdjudicationStatus.SCHEDULE_HEARING.name)
+      .jsonPath("$.reportedAdjudication.status").isEqualTo(ReportedAdjudicationStatus.SCHEDULED.name)
       .jsonPath("$.reportedAdjudication.hearings[1].outcome").doesNotExist()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReferralsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReferralsIntTest.kt
@@ -2,9 +2,11 @@ package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration
 
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.NotProceedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OicHearingType
+import java.time.LocalDateTime
 
 class ReferralsIntTest : OutcomeIntTest() {
 
@@ -78,23 +80,8 @@ class ReferralsIntTest : OutcomeIntTest() {
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(0)
   }
 
-  /*
-   Given a report adjudication is unscheduled
-   when its referred to police without a hearing
-   and the next step is Police Prosecution - No - Schedule a hearing
-   and the hearing is scheduled
-   and the hearing outcome is refer to inad
-   and the next step is schedule a hearing
-   and the hearing is scheduled
-   and the hearing outcome is refer to the police
-   and the next step is Police Prosecution - Yes
-   and then!  the user removes referral
-   i expect the last referral outcome (PROSECUTION) to be remove
-   and the last referral outcome REFER POLICE to be removed
-   and the hearing outcome of REFER POLICE to be removed
- */
   @Test
-  fun `remove referral, referral outcome and hearing outcome for a POLICE_REFER related to complex example`() {
+  fun `remove referral, referral outcome and hearing outcome for a POLICE_REFER related to complex example, police refer - no hearing, inad refer, police refer, prosecute`() {
     initDataForOutcome().createOutcome()
 
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
@@ -145,5 +132,109 @@ class ReferralsIntTest : OutcomeIntTest() {
       .jsonPath("$.reportedAdjudication.history[1].outcome.referralOutcome.code").isEqualTo(OutcomeCode.SCHEDULE_HEARING.name)
       .jsonPath("$.reportedAdjudication.history[2].hearing.oicHearingType").isEqualTo(OicHearingType.INAD_ADULT.name)
       .jsonPath("$.reportedAdjudication.history[2].outcome").doesNotExist()
+  }
+
+  @Test
+  fun `create hearing, refer to inad, and inad decides not to proceed, then remove referral`() {
+    initDataForOutcome()
+
+    prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+
+    integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION)
+
+    integrationTestData().createHearingOutcome(
+      IntegrationTestData.DEFAULT_ADJUDICATION, HearingOutcomeCode.REFER_INAD
+    )
+
+    integrationTestData().createOutcome(
+      IntegrationTestData.DEFAULT_ADJUDICATION, OutcomeCode.NOT_PROCEED, NotProceedReason.NOT_FAIR
+    ).expectStatus().isCreated
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
+      .jsonPath("$.reportedAdjudication.history.size()").isEqualTo(1)
+      .jsonPath("$.reportedAdjudication.history[0].outcome.outcome.code").isEqualTo(OutcomeCode.REFER_INAD.name)
+      .jsonPath("$.reportedAdjudication.history[0].outcome.referralOutcome.code").isEqualTo(OutcomeCode.NOT_PROCEED.name)
+      .jsonPath("$.reportedAdjudication.status").isEqualTo(ReportedAdjudicationStatus.NOT_PROCEED.name)
+
+    webTestClient.delete()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/remove-referral")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(0)
+      .jsonPath("$.reportedAdjudication.history.size()").isEqualTo(1)
+      .jsonPath("$.reportedAdjudication.history[0].outcome").doesNotExist()
+      .jsonPath("$.reportedAdjudication.status").isEqualTo(ReportedAdjudicationStatus.SCHEDULED.name)
+  }
+
+  @Test
+  fun `create hearing, refer to inad, schedule inad hearing, then remove the hearing`() {
+    initDataForOutcome()
+
+    prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+
+    integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION, LocalDateTime.now())
+
+    integrationTestData().createHearingOutcome(
+      IntegrationTestData.DEFAULT_ADJUDICATION, HearingOutcomeCode.REFER_INAD
+    )
+
+    integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION, LocalDateTime.now().plusDays(1))
+      .expectStatus().isCreated
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.history.size()").isEqualTo(2)
+      .jsonPath("$.reportedAdjudication.history[0].outcome.outcome.code").isEqualTo(OutcomeCode.REFER_INAD.name)
+      .jsonPath("$.reportedAdjudication.history[0].outcome.referralOutcome.code").isEqualTo(OutcomeCode.SCHEDULE_HEARING.name)
+      .jsonPath("$.reportedAdjudication.history[1].outcome").doesNotExist()
+
+    prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
+
+    webTestClient.delete()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.status")
+      .isEqualTo(ReportedAdjudicationStatus.SCHEDULED.name)
+      .jsonPath("$.reportedAdjudication.history.size()").isEqualTo(1)
+      .jsonPath("$.reportedAdjudication.history[0].outcome.outcome.code").isEqualTo(OutcomeCode.REFER_INAD.name)
+      .jsonPath("$.reportedAdjudication.history[0].outcome.referralOutcome").doesNotExist()
+  }
+
+  @Test
+  fun `create hearing, refer to police, schedule hearing, then remove the hearing`() {
+    initDataForOutcome()
+
+    prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+
+    integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION, LocalDateTime.now())
+
+    integrationTestData().createHearingOutcome(
+      IntegrationTestData.DEFAULT_ADJUDICATION, HearingOutcomeCode.REFER_POLICE
+    )
+
+    integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION, LocalDateTime.now().plusDays(1))
+      .expectStatus().isCreated
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.history.size()").isEqualTo(2)
+      .jsonPath("$.reportedAdjudication.history[0].outcome.outcome.code").isEqualTo(OutcomeCode.REFER_POLICE.name)
+      .jsonPath("$.reportedAdjudication.history[0].outcome.referralOutcome.code").isEqualTo(OutcomeCode.SCHEDULE_HEARING.name)
+      .jsonPath("$.reportedAdjudication.history[1].outcome").doesNotExist()
+
+    prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
+
+    webTestClient.delete()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.status")
+      .isEqualTo(ReportedAdjudicationStatus.SCHEDULED.name)
+      .jsonPath("$.reportedAdjudication.history.size()").isEqualTo(1)
+      .jsonPath("$.reportedAdjudication.history[0].outcome.outcome.code").isEqualTo(OutcomeCode.REFER_POLICE.name)
+      .jsonPath("$.reportedAdjudication.history[0].outcome.referralOutcome").doesNotExist()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReferralsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReferralsIntTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OicHearingType
 
 class ReferralsIntTest : OutcomeIntTest() {
 
@@ -104,7 +105,7 @@ class ReferralsIntTest : OutcomeIntTest() {
       IntegrationTestData.DEFAULT_ADJUDICATION, HearingOutcomeCode.REFER_INAD
     )
 
-    integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION, IntegrationTestData.DEFAULT_ADJUDICATION.dateTimeOfHearing!!.plusDays(1))
+    integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION, IntegrationTestData.DEFAULT_ADJUDICATION.dateTimeOfHearing!!.plusDays(1), OicHearingType.INAD_ADULT)
 
     integrationTestData().createHearingOutcome(
       IntegrationTestData.DEFAULT_ADJUDICATION, HearingOutcomeCode.REFER_POLICE
@@ -136,5 +137,13 @@ class ReferralsIntTest : OutcomeIntTest() {
       .jsonPath("$.reportedAdjudication.outcomes[1].referralOutcome.code").isEqualTo(OutcomeCode.SCHEDULE_HEARING.name)
       .jsonPath("$.reportedAdjudication.status").isEqualTo(ReportedAdjudicationStatus.SCHEDULED.name)
       .jsonPath("$.reportedAdjudication.hearings[1].outcome").doesNotExist()
+      .jsonPath("$.reportedAdjudication.history.size()").isEqualTo(3)
+      .jsonPath("$.reportedAdjudication.history[0].outcome.outcome.code").isEqualTo(OutcomeCode.REFER_POLICE.name)
+      .jsonPath("$.reportedAdjudication.history[0].hearing").doesNotExist()
+      .jsonPath("$.reportedAdjudication.history[0].outcome.referralOutcome.code").isEqualTo(OutcomeCode.SCHEDULE_HEARING.name)
+      .jsonPath("$.reportedAdjudication.history[1].outcome.outcome.code").isEqualTo(OutcomeCode.REFER_INAD.name)
+      .jsonPath("$.reportedAdjudication.history[1].outcome.referralOutcome.code").isEqualTo(OutcomeCode.SCHEDULE_HEARING.name)
+      .jsonPath("$.reportedAdjudication.history[2].hearing.oicHearingType").isEqualTo(OicHearingType.INAD_ADULT.name)
+      .jsonPath("$.reportedAdjudication.history[2].outcome").doesNotExist()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingServiceTest.kt
@@ -62,6 +62,7 @@ class HearingServiceTest : ReportedAdjudicationTestBase() {
         it.createdByUserId = ""
         it.createDateTime = LocalDateTime.now()
         it.hearings.clear()
+        it.outcomes.clear()
       }
 
     @BeforeEach
@@ -176,7 +177,7 @@ class HearingServiceTest : ReportedAdjudicationTestBase() {
 
     @CsvSource("REFER_POLICE", "REFER_INAD")
     @ParameterizedTest
-    fun `create a NO_PROSECUTION outcome when creating a hearing if the previous outcome is a REFER_POLICE`(code: OutcomeCode) {
+    fun `create a SCHEDULE_HEARING outcome when creating a hearing if the previous outcome is a REFER_POLICE`(code: OutcomeCode) {
       val reportedAdjudicationReferPolice = entityBuilder.reportedAdjudication(dateTime = DATE_TIME_OF_INCIDENT)
         .also {
           it.createdByUserId = ""

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
@@ -225,7 +225,7 @@ class OutcomeServiceTest : ReportedAdjudicationTestBase() {
       it.outcomes.add(
         Outcome(
           code = OutcomeCode.SCHEDULE_HEARING,
-        ).also { o -> o.createDateTime = LocalDateTime.now().plusDays(1) }
+        ).also { o -> o.createDateTime = LocalDateTime.now() }
       )
       it.outcomes.add(
         Outcome(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
@@ -513,7 +513,7 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
   @Nested
   inner class OutcomesHistory {
 
-    private var reportedAdjudication = entityBuilder.reportedAdjudication().also {
+    private val reportedAdjudication = entityBuilder.reportedAdjudication().also {
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
       it.hearings.clear()
@@ -532,9 +532,11 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       it.outcomes.add(Outcome(code = OutcomeCode.NOT_PROCEED))
     }
 
-    private var reportedAdjudication3 = reportedAdjudication.also {
+    private val reportedAdjudication3 = entityBuilder.reportedAdjudication().also {
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
+
+      reportedAdjudication.outcomes.forEach { o -> it.outcomes.add(o) }
       it.outcomes.add(
         Outcome(code = OutcomeCode.SCHEDULE_HEARING).also {
           o ->
@@ -543,13 +545,23 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
     }
 
-    private var reportedAdjudication4 = reportedAdjudication3.also {
+    private val reportedAdjudication4 = entityBuilder.reportedAdjudication().also {
+      it.createDateTime = LocalDateTime.now()
+      it.createdByUserId = ""
+
+      reportedAdjudication3.outcomes.forEach { o -> it.outcomes.add(o) }
       it.hearings.add(
         Hearing(locationId = 1, agencyId = "", reportNumber = 1L, oicHearingType = OicHearingType.GOV_ADULT, dateTimeOfHearing = LocalDateTime.now().plusDays(1), oicHearingId = 1L)
       )
     }
 
-    private var reportedAdjudication5 = reportedAdjudication4.also {
+    private val reportedAdjudication5 = entityBuilder.reportedAdjudication().also {
+      it.createDateTime = LocalDateTime.now()
+      it.createdByUserId = ""
+
+      reportedAdjudication4.outcomes.forEach { o -> it.outcomes.add(o) }
+      reportedAdjudication4.hearings.forEach { h -> it.hearings.add(h) }
+
       it.outcomes.add(
         Outcome(code = OutcomeCode.REFER_INAD).also {
           o ->
@@ -562,7 +574,13 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       }
     }
 
-    private var reportedAdjudication6 = reportedAdjudication5.also {
+    private val reportedAdjudication6 = entityBuilder.reportedAdjudication().also {
+      it.createDateTime = LocalDateTime.now()
+      it.createdByUserId = ""
+
+      reportedAdjudication5.outcomes.forEach { o -> it.outcomes.add(o) }
+      reportedAdjudication5.hearings.forEach { h -> it.hearings.add(h) }
+
       it.hearings.add(
         Hearing(
           locationId = 1, agencyId = "", reportNumber = 1L, oicHearingType = OicHearingType.INAD_ADULT, dateTimeOfHearing = LocalDateTime.now().plusDays(2), oicHearingId = 1L,
@@ -570,7 +588,13 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
     }
 
-    private var reportedAdjudication7 = reportedAdjudication6.also {
+    private val reportedAdjudication7 = entityBuilder.reportedAdjudication().also {
+      it.createDateTime = LocalDateTime.now()
+      it.createdByUserId = ""
+
+      reportedAdjudication6.outcomes.forEach { o -> it.outcomes.add(o) }
+      reportedAdjudication6.hearings.forEach { h -> it.hearings.add(h) }
+
       it.outcomes.add(
         Outcome(code = OutcomeCode.REFER_POLICE).also {
           o ->
@@ -584,7 +608,13 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       }
     }
 
-    private val reportedAdjudication8 = reportedAdjudication7.also {
+    private val reportedAdjudication8 = entityBuilder.reportedAdjudication().also {
+      it.createDateTime = LocalDateTime.now()
+      it.createdByUserId = ""
+
+      reportedAdjudication7.outcomes.forEach { o -> it.outcomes.add(o) }
+      reportedAdjudication7.hearings.forEach { h -> it.hearings.add(h) }
+
       it.outcomes.add(
         Outcome(code = OutcomeCode.PROSECUTION).also {
           o ->
@@ -641,6 +671,38 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       whenever(reportedAdjudicationRepository.findByReportNumber(7)).thenReturn(reportedAdjudication7)
       whenever(reportedAdjudicationRepository.findByReportNumber(8)).thenReturn(reportedAdjudication8)
       whenever(reportedAdjudicationRepository.findByReportNumber(9)).thenReturn(reportedAdjudication9)
+    }
+
+    @Test
+    fun `no data`() {
+      whenever(reportedAdjudicationRepository.findByReportNumber(0)).thenReturn(
+        entityBuilder.reportedAdjudication().also {
+          it.createDateTime = LocalDateTime.now()
+          it.createdByUserId = ""
+          it.hearings.clear()
+        }
+      )
+
+      val result = reportedAdjudicationService.getReportedAdjudicationDetails(0)
+
+      assertThat(result.history.isEmpty()).isTrue
+    }
+
+    @Test
+    fun `single hearing`() {
+      whenever(reportedAdjudicationRepository.findByReportNumber(10)).thenReturn(
+        entityBuilder.reportedAdjudication().also {
+          it.createDateTime = LocalDateTime.now()
+          it.createdByUserId = ""
+        }
+      )
+
+      val result = reportedAdjudicationService.getReportedAdjudicationDetails(10)
+
+      assertThat(result.history.size).isEqualTo(1)
+      assertThat(result.history.first().hearing).isNotNull
+      assertThat(result.history.first().outcome).isNull()
+      assertThat(result.history.first().hearing!!.outcome).isNull()
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
@@ -512,7 +512,7 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
   @Nested
   inner class OutcomesHistory {
 
-    private val reportedAdjudication = entityBuilder.reportedAdjudication().also {
+    private val reportedAdjudicationReferPolice = entityBuilder.reportedAdjudication().also {
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
       it.hearings.clear()
@@ -524,19 +524,19 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
     }
 
-    private val reportedAdjudication2 = entityBuilder.reportedAdjudication().also {
+    private val reportedAdjudicationNotProceed = entityBuilder.reportedAdjudication().also {
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
       it.hearings.clear()
       it.outcomes.add(Outcome(code = OutcomeCode.NOT_PROCEED))
     }
 
-    private val reportedAdjudication4 = entityBuilder.reportedAdjudication().also {
+    private val reportedAdjudicationNoProsecution = entityBuilder.reportedAdjudication().also {
       it.hearings.clear()
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
 
-      reportedAdjudication.outcomes.forEach { o -> it.outcomes.add(o.copy()) }
+      reportedAdjudicationReferPolice.outcomes.forEach { o -> it.outcomes.add(o.copy()) }
       it.outcomes.add(
         Outcome(code = OutcomeCode.SCHEDULE_HEARING).also {
           it.createDateTime = LocalDateTime.now().plusDays(1)
@@ -547,13 +547,13 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
     }
 
-    private val reportedAdjudication5 = entityBuilder.reportedAdjudication().also {
+    private val reportedAdjudicationReferInad = entityBuilder.reportedAdjudication().also {
       it.hearings.clear()
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
 
-      reportedAdjudication4.outcomes.forEach { o -> it.outcomes.add(o.copy()) }
-      reportedAdjudication4.hearings.forEach { h -> it.hearings.add(h.copy()) }
+      reportedAdjudicationNoProsecution.outcomes.forEach { o -> it.outcomes.add(o.copy()) }
+      reportedAdjudicationNoProsecution.hearings.forEach { h -> it.hearings.add(h.copy()) }
 
       it.outcomes.add(
         Outcome(code = OutcomeCode.REFER_INAD).also {
@@ -573,13 +573,13 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       }
     }
 
-    private val reportedAdjudication6 = entityBuilder.reportedAdjudication().also {
+    private val reportedAdjudicationInadHearing = entityBuilder.reportedAdjudication().also {
       it.hearings.clear()
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
 
-      reportedAdjudication5.outcomes.forEach { o -> it.outcomes.add(o.copy()) }
-      reportedAdjudication5.hearings.forEach { h -> it.hearings.add(h.copy()) }
+      reportedAdjudicationReferInad.outcomes.forEach { o -> it.outcomes.add(o.copy()) }
+      reportedAdjudicationReferInad.hearings.forEach { h -> it.hearings.add(h.copy()) }
 
       it.hearings.add(
         Hearing(
@@ -588,13 +588,13 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
     }
 
-    private val reportedAdjudication7 = entityBuilder.reportedAdjudication().also {
+    private val reportedAdjudicationInadReferPolice = entityBuilder.reportedAdjudication().also {
       it.hearings.clear()
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
 
-      reportedAdjudication6.outcomes.forEach { o -> it.outcomes.add(o.copy()) }
-      reportedAdjudication6.hearings.forEach { h -> it.hearings.add(h.copy()) }
+      reportedAdjudicationInadHearing.outcomes.forEach { o -> it.outcomes.add(o.copy()) }
+      reportedAdjudicationInadHearing.hearings.forEach { h -> it.hearings.add(h.copy()) }
 
       it.outcomes.add(
         Outcome(code = OutcomeCode.REFER_POLICE).also {
@@ -609,13 +609,13 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       }
     }
 
-    private val reportedAdjudication8 = entityBuilder.reportedAdjudication().also {
+    private val reportedAdjudicationProsecution = entityBuilder.reportedAdjudication().also {
       it.hearings.clear()
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
 
-      reportedAdjudication7.outcomes.forEach { o -> it.outcomes.add(o.copy()) }
-      reportedAdjudication7.hearings.forEach { h -> it.hearings.add(h.copy()) }
+      reportedAdjudicationInadReferPolice.outcomes.forEach { o -> it.outcomes.add(o.copy()) }
+      reportedAdjudicationInadReferPolice.hearings.forEach { h -> it.hearings.add(h.copy()) }
 
       it.outcomes.add(
         Outcome(code = OutcomeCode.PROSECUTION).also {
@@ -625,7 +625,7 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
     }
 
-    private val reportedAdjudication11 = entityBuilder.reportedAdjudication().also {
+    private val reportedAdjudicationReferPoliceNotProceed = entityBuilder.reportedAdjudication().also {
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
       it.hearings.clear()
@@ -644,7 +644,7 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
     }
 
-    private val reportedAdjudication9 = entityBuilder.reportedAdjudication().also {
+    private val reportedAdjudicationProsecutionAllHearings = entityBuilder.reportedAdjudication().also {
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
       it.hearings.clear()
@@ -687,17 +687,42 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
     }
 
+    private val reportedAdjudicationReferInadNotProceed = entityBuilder.reportedAdjudication().also {
+      it.createDateTime = LocalDateTime.now()
+      it.createdByUserId = ""
+      it.hearings.clear()
+
+      it.hearings.add(
+        Hearing(
+          locationId = 1, agencyId = "", reportNumber = 1L, oicHearingType = OicHearingType.GOV_ADULT, dateTimeOfHearing = LocalDateTime.now().plusDays(1), oicHearingId = 1L,
+          hearingOutcome = HearingOutcome(code = HearingOutcomeCode.REFER_INAD, adjudicator = "")
+        )
+      )
+
+      it.outcomes.add(
+        Outcome(code = OutcomeCode.REFER_INAD).also {
+          it.createDateTime = LocalDateTime.now().plusDays(1)
+        }
+      )
+      it.outcomes.add(
+        Outcome(code = OutcomeCode.NOT_PROCEED).also {
+          it.createDateTime = LocalDateTime.now().plusDays(2)
+        }
+      )
+    }
+
     @BeforeEach
     fun `init`() {
-      whenever(reportedAdjudicationRepository.findByReportNumber(1)).thenReturn(reportedAdjudication)
-      whenever(reportedAdjudicationRepository.findByReportNumber(2)).thenReturn(reportedAdjudication2)
-      whenever(reportedAdjudicationRepository.findByReportNumber(4)).thenReturn(reportedAdjudication4)
-      whenever(reportedAdjudicationRepository.findByReportNumber(5)).thenReturn(reportedAdjudication5)
-      whenever(reportedAdjudicationRepository.findByReportNumber(6)).thenReturn(reportedAdjudication6)
-      whenever(reportedAdjudicationRepository.findByReportNumber(7)).thenReturn(reportedAdjudication7)
-      whenever(reportedAdjudicationRepository.findByReportNumber(8)).thenReturn(reportedAdjudication8)
-      whenever(reportedAdjudicationRepository.findByReportNumber(9)).thenReturn(reportedAdjudication9)
-      whenever(reportedAdjudicationRepository.findByReportNumber(11)).thenReturn(reportedAdjudication11)
+      whenever(reportedAdjudicationRepository.findByReportNumber(1)).thenReturn(reportedAdjudicationReferPolice)
+      whenever(reportedAdjudicationRepository.findByReportNumber(2)).thenReturn(reportedAdjudicationNotProceed)
+      whenever(reportedAdjudicationRepository.findByReportNumber(4)).thenReturn(reportedAdjudicationNoProsecution)
+      whenever(reportedAdjudicationRepository.findByReportNumber(5)).thenReturn(reportedAdjudicationReferInad)
+      whenever(reportedAdjudicationRepository.findByReportNumber(6)).thenReturn(reportedAdjudicationInadHearing)
+      whenever(reportedAdjudicationRepository.findByReportNumber(7)).thenReturn(reportedAdjudicationInadReferPolice)
+      whenever(reportedAdjudicationRepository.findByReportNumber(8)).thenReturn(reportedAdjudicationProsecution)
+      whenever(reportedAdjudicationRepository.findByReportNumber(9)).thenReturn(reportedAdjudicationProsecutionAllHearings)
+      whenever(reportedAdjudicationRepository.findByReportNumber(11)).thenReturn(reportedAdjudicationReferPoliceNotProceed)
+      whenever(reportedAdjudicationRepository.findByReportNumber(12)).thenReturn(reportedAdjudicationReferInadNotProceed)
     }
 
     @Test
@@ -838,6 +863,20 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       assertThat(result.history.first().hearing).isNull()
       assertThat(result.history.first().outcome).isNotNull
       assertThat(result.history.first().outcome!!.outcome.code).isEqualTo(OutcomeCode.REFER_POLICE)
+      assertThat(result.history.first().outcome!!.referralOutcome).isNotNull
+      assertThat(result.history.first().outcome!!.referralOutcome!!.code).isEqualTo(OutcomeCode.NOT_PROCEED)
+    }
+
+    @Test
+    fun `outcome history DTO - hearing refers to INAD who chooses NOT_PROCEED `() {
+      val result = reportedAdjudicationService.getReportedAdjudicationDetails(12)
+      assertThat(result.history.size).isEqualTo(1)
+
+      assertThat(result.history.first().hearing).isNotNull
+      assertThat(result.history.first().hearing!!.outcome).isNotNull
+      assertThat(result.history.first().hearing!!.outcome!!.code).isEqualTo(HearingOutcomeCode.REFER_INAD)
+      assertThat(result.history.first().outcome).isNotNull
+      assertThat(result.history.first().outcome!!.outcome.code).isEqualTo(OutcomeCode.REFER_INAD)
       assertThat(result.history.first().outcome!!.referralOutcome).isNotNull
       assertThat(result.history.first().outcome!!.referralOutcome!!.code).isEqualTo(OutcomeCode.NOT_PROCEED)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
@@ -505,6 +505,15 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
     }
   }
 
+  @Nested
+  inner class OutcomesHistory {
+
+    @Test
+    fun `outcome history DTO`() {
+      TODO("implement me - work out what this should look like and build up adjudication and expected output")
+    }
+  }
+
   companion object {
     private val DATE_TIME_REPORTED_ADJUDICATION_EXPIRES = LocalDateTime.of(2010, 10, 14, 10, 0)
     private val REPORTED_DATE_TIME = DATE_TIME_OF_INCIDENT.plusDays(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
@@ -206,7 +206,6 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       "RETURNED, REJECTED",
       "RETURNED, RETURNED",
       "SCHEDULED, SCHEDULED",
-      "REFER_POLICE, SCHEDULED",
       "NOT_PROCEED, SCHEDULED",
     )
     fun `setting status for a reported adjudication throws an illegal state exception for invalid transitions`(
@@ -532,40 +531,40 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       it.outcomes.add(Outcome(code = OutcomeCode.NOT_PROCEED))
     }
 
-    private val reportedAdjudication3 = entityBuilder.reportedAdjudication().also {
+    private val reportedAdjudication4 = entityBuilder.reportedAdjudication().also {
+      it.hearings.clear()
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
 
-      reportedAdjudication.outcomes.forEach { o -> it.outcomes.add(o) }
+      reportedAdjudication.outcomes.forEach { o -> it.outcomes.add(o.copy()) }
       it.outcomes.add(
         Outcome(code = OutcomeCode.SCHEDULE_HEARING).also {
-          o ->
-          o.createDateTime = LocalDateTime.now().plusDays(1)
+          it.createDateTime = LocalDateTime.now().plusDays(1)
         }
       )
-    }
-
-    private val reportedAdjudication4 = entityBuilder.reportedAdjudication().also {
-      it.createDateTime = LocalDateTime.now()
-      it.createdByUserId = ""
-
-      reportedAdjudication3.outcomes.forEach { o -> it.outcomes.add(o) }
       it.hearings.add(
         Hearing(locationId = 1, agencyId = "", reportNumber = 1L, oicHearingType = OicHearingType.GOV_ADULT, dateTimeOfHearing = LocalDateTime.now().plusDays(1), oicHearingId = 1L)
       )
     }
 
     private val reportedAdjudication5 = entityBuilder.reportedAdjudication().also {
+      it.hearings.clear()
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
 
-      reportedAdjudication4.outcomes.forEach { o -> it.outcomes.add(o) }
-      reportedAdjudication4.hearings.forEach { h -> it.hearings.add(h) }
+      reportedAdjudication4.outcomes.forEach { o -> it.outcomes.add(o.copy()) }
+      reportedAdjudication4.hearings.forEach { h -> it.hearings.add(h.copy()) }
 
       it.outcomes.add(
         Outcome(code = OutcomeCode.REFER_INAD).also {
           o ->
           o.createDateTime = LocalDateTime.now().plusDays(2)
+        }
+      )
+      it.outcomes.add(
+        Outcome(code = OutcomeCode.SCHEDULE_HEARING).also {
+          o ->
+          o.createDateTime = LocalDateTime.now().plusDays(2).plusHours(1)
         }
       )
 
@@ -575,11 +574,12 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
     }
 
     private val reportedAdjudication6 = entityBuilder.reportedAdjudication().also {
+      it.hearings.clear()
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
 
-      reportedAdjudication5.outcomes.forEach { o -> it.outcomes.add(o) }
-      reportedAdjudication5.hearings.forEach { h -> it.hearings.add(h) }
+      reportedAdjudication5.outcomes.forEach { o -> it.outcomes.add(o.copy()) }
+      reportedAdjudication5.hearings.forEach { h -> it.hearings.add(h.copy()) }
 
       it.hearings.add(
         Hearing(
@@ -589,16 +589,17 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
     }
 
     private val reportedAdjudication7 = entityBuilder.reportedAdjudication().also {
+      it.hearings.clear()
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
 
-      reportedAdjudication6.outcomes.forEach { o -> it.outcomes.add(o) }
-      reportedAdjudication6.hearings.forEach { h -> it.hearings.add(h) }
+      reportedAdjudication6.outcomes.forEach { o -> it.outcomes.add(o.copy()) }
+      reportedAdjudication6.hearings.forEach { h -> it.hearings.add(h.copy()) }
 
       it.outcomes.add(
         Outcome(code = OutcomeCode.REFER_POLICE).also {
           o ->
-          o.createDateTime = LocalDateTime.now().plusDays(3)
+          o.createDateTime = LocalDateTime.now().plusDays(4)
         }
       )
 
@@ -609,16 +610,36 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
     }
 
     private val reportedAdjudication8 = entityBuilder.reportedAdjudication().also {
+      it.hearings.clear()
       it.createDateTime = LocalDateTime.now()
       it.createdByUserId = ""
 
-      reportedAdjudication7.outcomes.forEach { o -> it.outcomes.add(o) }
-      reportedAdjudication7.hearings.forEach { h -> it.hearings.add(h) }
+      reportedAdjudication7.outcomes.forEach { o -> it.outcomes.add(o.copy()) }
+      reportedAdjudication7.hearings.forEach { h -> it.hearings.add(h.copy()) }
 
       it.outcomes.add(
         Outcome(code = OutcomeCode.PROSECUTION).also {
           o ->
-          o.createDateTime = LocalDateTime.now().plusDays(4)
+          o.createDateTime = LocalDateTime.now().plusDays(5)
+        }
+      )
+    }
+
+    private val reportedAdjudication11 = entityBuilder.reportedAdjudication().also {
+      it.createDateTime = LocalDateTime.now()
+      it.createdByUserId = ""
+      it.hearings.clear()
+
+      it.outcomes.add(
+        Outcome(code = OutcomeCode.REFER_POLICE).also {
+          o ->
+          o.createDateTime = LocalDateTime.now().plusDays(2)
+        }
+      )
+      it.outcomes.add(
+        Outcome(code = OutcomeCode.NOT_PROCEED).also {
+          o ->
+          o.createDateTime = LocalDateTime.now().plusDays(3)
         }
       )
     }
@@ -634,15 +655,21 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
         }
       )
       it.outcomes.add(
-        Outcome(code = OutcomeCode.REFER_POLICE).also {
+        Outcome(code = OutcomeCode.SCHEDULE_HEARING).also {
           o ->
           o.createDateTime = LocalDateTime.now().plusDays(3)
         }
       )
       it.outcomes.add(
-        Outcome(code = OutcomeCode.PROSECUTION).also {
+        Outcome(code = OutcomeCode.REFER_POLICE).also {
           o ->
           o.createDateTime = LocalDateTime.now().plusDays(4)
+        }
+      )
+      it.outcomes.add(
+        Outcome(code = OutcomeCode.PROSECUTION).also {
+          o ->
+          o.createDateTime = LocalDateTime.now().plusDays(5)
         }
       )
 
@@ -664,13 +691,13 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
     fun `init`() {
       whenever(reportedAdjudicationRepository.findByReportNumber(1)).thenReturn(reportedAdjudication)
       whenever(reportedAdjudicationRepository.findByReportNumber(2)).thenReturn(reportedAdjudication2)
-      whenever(reportedAdjudicationRepository.findByReportNumber(3)).thenReturn(reportedAdjudication3)
       whenever(reportedAdjudicationRepository.findByReportNumber(4)).thenReturn(reportedAdjudication4)
       whenever(reportedAdjudicationRepository.findByReportNumber(5)).thenReturn(reportedAdjudication5)
       whenever(reportedAdjudicationRepository.findByReportNumber(6)).thenReturn(reportedAdjudication6)
       whenever(reportedAdjudicationRepository.findByReportNumber(7)).thenReturn(reportedAdjudication7)
       whenever(reportedAdjudicationRepository.findByReportNumber(8)).thenReturn(reportedAdjudication8)
       whenever(reportedAdjudicationRepository.findByReportNumber(9)).thenReturn(reportedAdjudication9)
+      whenever(reportedAdjudicationRepository.findByReportNumber(11)).thenReturn(reportedAdjudication11)
     }
 
     @Test
@@ -727,12 +754,7 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       assertThat(result.history.first().outcome!!.outcome).isNotNull
       assertThat(result.history.first().outcome!!.outcome.code).isEqualTo(OutcomeCode.NOT_PROCEED)
     }
-    @Test
-    fun `outcome history DTO - Refer police, No prosecution, schedule hearing`() {
-      val result = reportedAdjudicationService.getReportedAdjudicationDetails(3).validateFirstItem()
 
-      assertThat(result.history.size).isEqualTo(1)
-    }
     @Test
     fun `outcome history DTO - Refer police, No prosecution, hearing scheduled`() {
       val result = reportedAdjudicationService.getReportedAdjudicationDetails(4).validateFirstItem()
@@ -769,7 +791,7 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       assertThat(result.history.last().hearing!!.outcome).isNotNull
       assertThat(result.history.last().hearing!!.outcome!!.code).isEqualTo(HearingOutcomeCode.REFER_POLICE)
       assertThat(result.history.last().outcome).isNotNull
-      assertThat(result.history.last().outcome!!.outcome).isEqualTo(OutcomeCode.REFER_POLICE)
+      assertThat(result.history.last().outcome!!.outcome.code).isEqualTo(OutcomeCode.REFER_POLICE)
       assertThat(result.history.last().outcome!!.referralOutcome).isNull()
     }
     @Test
@@ -782,7 +804,7 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       assertThat(result.history.last().hearing!!.outcome).isNotNull
       assertThat(result.history.last().hearing!!.outcome!!.code).isEqualTo(HearingOutcomeCode.REFER_POLICE)
       assertThat(result.history.last().outcome).isNotNull
-      assertThat(result.history.last().outcome!!.outcome).isEqualTo(OutcomeCode.REFER_POLICE)
+      assertThat(result.history.last().outcome!!.outcome.code).isEqualTo(OutcomeCode.REFER_POLICE)
       assertThat(result.history.last().outcome!!.referralOutcome).isNotNull
       assertThat(result.history.last().outcome!!.referralOutcome!!.code).isEqualTo(OutcomeCode.PROSECUTION)
     }
@@ -806,6 +828,18 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       assertThat(result.history.last().outcome!!.outcome.code).isEqualTo(OutcomeCode.REFER_POLICE)
       assertThat(result.history.last().outcome!!.referralOutcome).isNotNull
       assertThat(result.history.last().outcome!!.referralOutcome!!.code).isEqualTo(OutcomeCode.PROSECUTION)
+    }
+
+    @Test
+    fun `outcome history DTO - Refer police no hearing, No prosecution, Not proceed`() {
+      val result = reportedAdjudicationService.getReportedAdjudicationDetails(11)
+      assertThat(result.history.size).isEqualTo(1)
+
+      assertThat(result.history.first().hearing).isNull()
+      assertThat(result.history.first().outcome).isNotNull
+      assertThat(result.history.first().outcome!!.outcome.code).isEqualTo(OutcomeCode.REFER_POLICE)
+      assertThat(result.history.first().outcome!!.referralOutcome).isNotNull
+      assertThat(result.history.first().outcome!!.referralOutcome!!.code).isEqualTo(OutcomeCode.NOT_PROCEED)
     }
 
     private fun ReportedAdjudicationDto.validateFirstItem(): ReportedAdjudicationDto {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
@@ -726,7 +726,24 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
     }
     @Test
     fun `outcome history DTO - Schedule hearing, refer to inad, scheduled hearing, refer to police, prosecution yes`() {
-      TODO("implement me - work out what this should look like and build up adjudication and expected output")
+      val result = reportedAdjudicationService.getReportedAdjudicationDetails(9)
+
+      assertThat(result.history.size).isEqualTo(2)
+      assertThat(result.history.first().hearing).isNotNull
+      assertThat(result.history.first().hearing!!.outcome).isNotNull
+      assertThat(result.history.first().hearing!!.outcome!!.code).isEqualTo(HearingOutcomeCode.REFER_INAD)
+      assertThat(result.history.first().outcome).isNotNull
+      assertThat(result.history.first().outcome!!.outcome.code).isEqualTo(OutcomeCode.REFER_INAD)
+      assertThat(result.history.first().outcome!!.referralOutcome).isNotNull
+      assertThat(result.history.first().outcome!!.referralOutcome!!.code).isEqualTo(OutcomeCode.SCHEDULE_HEARING)
+
+      assertThat(result.history.last().hearing).isNotNull
+      assertThat(result.history.last().hearing!!.outcome).isNotNull
+      assertThat(result.history.last().hearing!!.outcome!!.code).isEqualTo(HearingOutcomeCode.REFER_POLICE)
+      assertThat(result.history.last().outcome).isNotNull
+      assertThat(result.history.last().outcome!!.outcome.code).isEqualTo(OutcomeCode.REFER_POLICE)
+      assertThat(result.history.last().outcome!!.referralOutcome).isNotNull
+      assertThat(result.history.last().outcome!!.referralOutcome!!.code).isEqualTo(OutcomeCode.PROSECUTION)
     }
 
     private fun ReportedAdjudicationDto.validateFirstItem(): ReportedAdjudicationDto {


### PR DESCRIPTION
New DTO to represent the history for the referrals and hearings tab

-  Automate the schedule a hearing outcome for refers to add correct referral outcome
-  for refer police, this means they selected prosecution NO, schedule a hearing
- for refer inad, this means the selected schedule a hearing
- Automates the removal of the schedule hearing, if deleting a hearing created from a referral outcome

