### PR TITLE
NN-4870 old hearing version restored

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingController.kt
@@ -71,6 +71,48 @@ class HearingController(
   @PostMapping(value = ["/{adjudicationNumber}/hearing"])
   @Operation(summary = "Create a new hearing")
   @ResponseStatus(HttpStatus.CREATED)
+  fun createHearingV1(
+    @PathVariable(name = "adjudicationNumber") adjudicationNumber: Long,
+    @RequestBody hearingRequest: HearingRequest
+  ): ReportedAdjudicationResponse {
+    val reportedAdjudication = hearingService.createHearingV1(
+      adjudicationNumber, hearingRequest.locationId, hearingRequest.dateTimeOfHearing, hearingRequest.oicHearingType,
+    )
+
+    return ReportedAdjudicationResponse(reportedAdjudication)
+  }
+
+  @PutMapping(value = ["/{adjudicationNumber}/hearing/{hearingId}"])
+  @Operation(summary = "Amend an existing hearing")
+  @ResponseStatus(HttpStatus.OK)
+  fun amendHearingV1(
+    @PathVariable(name = "adjudicationNumber") adjudicationNumber: Long,
+    @PathVariable(name = "hearingId") hearingId: Long,
+    @RequestBody hearingRequest: HearingRequest
+  ): ReportedAdjudicationResponse {
+    val reportedAdjudication = hearingService.amendHearingV1(
+      adjudicationNumber, hearingId, hearingRequest.locationId, hearingRequest.dateTimeOfHearing, hearingRequest.oicHearingType,
+    )
+
+    return ReportedAdjudicationResponse(reportedAdjudication)
+  }
+
+  @DeleteMapping(value = ["/{adjudicationNumber}/hearing/{hearingId}"])
+  @Operation(summary = "deletes a hearing")
+  @ResponseStatus(HttpStatus.OK)
+  fun deleteHearingV1(
+    @PathVariable(name = "adjudicationNumber") adjudicationNumber: Long,
+    @PathVariable(name = "hearingId") hearingId: Long,
+  ): ReportedAdjudicationResponse {
+    val reportedAdjudication = hearingService.deleteHearingV1(
+      adjudicationNumber, hearingId
+    )
+    return ReportedAdjudicationResponse(reportedAdjudication)
+  }
+
+  @PostMapping(value = ["/{adjudicationNumber}/hearing/v2"])
+  @Operation(summary = "Create a new hearing")
+  @ResponseStatus(HttpStatus.CREATED)
   fun createHearing(
     @PathVariable(name = "adjudicationNumber") adjudicationNumber: Long,
     @RequestBody hearingRequest: HearingRequest
@@ -85,8 +127,8 @@ class HearingController(
     return ReportedAdjudicationResponse(reportedAdjudication)
   }
 
-  @PutMapping(value = ["/{adjudicationNumber}/hearing"])
-  @Operation(summary = "Amends leatest hearing")
+  @PutMapping(value = ["/{adjudicationNumber}/hearing/v2"])
+  @Operation(summary = "Amends latest hearing")
   @ResponseStatus(HttpStatus.OK)
   fun amendHearing(
     @PathVariable(name = "adjudicationNumber") adjudicationNumber: Long,
@@ -102,7 +144,7 @@ class HearingController(
     return ReportedAdjudicationResponse(reportedAdjudication)
   }
 
-  @DeleteMapping(value = ["/{adjudicationNumber}/hearing"])
+  @DeleteMapping(value = ["/{adjudicationNumber}/hearing/v2"])
   @Operation(summary = "deletes latest hearing")
   @ResponseStatus(HttpStatus.OK)
   fun deleteHearing(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingService.kt
@@ -36,6 +36,88 @@ class HearingService(
   authenticationFacade,
 ) {
 
+  fun createHearingV1(adjudicationNumber: Long, locationId: Long, dateTimeOfHearing: LocalDateTime, oicHearingType: OicHearingType): ReportedAdjudicationDto {
+    val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber).also {
+      oicHearingType.isValidState(it.isYouthOffender)
+    }
+
+    val oicHearingId = prisonApiGateway.createHearing(
+      adjudicationNumber = adjudicationNumber,
+      oicHearingRequest = OicHearingRequest(
+        dateTimeOfHearing = dateTimeOfHearing,
+        hearingLocationId = locationId,
+        oicHearingType = oicHearingType,
+      )
+    )
+
+    reportedAdjudication.let {
+      it.hearings.add(
+        Hearing(
+          agencyId = reportedAdjudication.agencyId,
+          reportNumber = reportedAdjudication.reportNumber,
+          locationId = locationId,
+          dateTimeOfHearing = dateTimeOfHearing,
+          oicHearingId = oicHearingId,
+          oicHearingType = oicHearingType,
+        )
+      )
+      if (it.status != ReportedAdjudicationStatus.SCHEDULED)
+        it.status = ReportedAdjudicationStatus.SCHEDULED
+
+      it.dateTimeOfFirstHearing = it.calcFirstHearingDate()
+    }
+
+    return saveToDto(reportedAdjudication)
+  }
+
+  fun amendHearingV1(adjudicationNumber: Long, hearingId: Long, locationId: Long, dateTimeOfHearing: LocalDateTime, oicHearingType: OicHearingType): ReportedAdjudicationDto {
+    val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber).also {
+      oicHearingType.isValidState(it.isYouthOffender)
+    }
+
+    val hearingToEdit = reportedAdjudication.hearings.find { it.id!! == hearingId } ?: throwHearingNotFoundException()
+
+    prisonApiGateway.amendHearing(
+      adjudicationNumber = adjudicationNumber,
+      oicHearingId = hearingToEdit.oicHearingId,
+      oicHearingRequest = OicHearingRequest(
+        dateTimeOfHearing = dateTimeOfHearing,
+        hearingLocationId = locationId,
+        oicHearingType = oicHearingType
+      )
+    )
+
+    hearingToEdit.let {
+      it.dateTimeOfHearing = dateTimeOfHearing
+      it.locationId = locationId
+      it.oicHearingType = oicHearingType
+    }
+
+    reportedAdjudication.dateTimeOfFirstHearing = reportedAdjudication.calcFirstHearingDate()
+
+    return saveToDto(reportedAdjudication)
+  }
+
+  fun deleteHearingV1(adjudicationNumber: Long, hearingId: Long): ReportedAdjudicationDto {
+    val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber)
+    val hearingToRemove = reportedAdjudication.hearings.find { it.id!! == hearingId } ?: throwHearingNotFoundException()
+
+    prisonApiGateway.deleteHearing(
+      adjudicationNumber = adjudicationNumber,
+      oicHearingId = hearingToRemove.oicHearingId
+    )
+
+    reportedAdjudication.let {
+      it.hearings.remove(hearingToRemove)
+      if (it.hearings.isEmpty())
+        it.status = ReportedAdjudicationStatus.UNSCHEDULED
+
+      it.dateTimeOfFirstHearing = it.calcFirstHearingDate()
+    }
+
+    return saveToDto(reportedAdjudication)
+  }
+
   fun createHearing(adjudicationNumber: Long, locationId: Long, dateTimeOfHearing: LocalDateTime, oicHearingType: OicHearingType): ReportedAdjudicationDto {
     val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber).also {
       oicHearingType.isValidState(it.isYouthOffender)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingControllerTest.kt
@@ -93,7 +93,7 @@ class HearingControllerTest : TestControllerBase() {
       val body = objectMapper.writeValueAsString(hearing)
       return mockMvc
         .perform(
-          MockMvcRequestBuilders.post("/reported-adjudications/$id/hearing")
+          MockMvcRequestBuilders.post("/reported-adjudications/$id/hearing/v2")
             .header("Content-Type", "application/json")
             .content(body)
         )
@@ -142,7 +142,7 @@ class HearingControllerTest : TestControllerBase() {
     ): ResultActions {
       return mockMvc
         .perform(
-          MockMvcRequestBuilders.delete("/reported-adjudications/$id/hearing")
+          MockMvcRequestBuilders.delete("/reported-adjudications/$id/hearing/v2")
             .header("Content-Type", "application/json")
         )
     }
@@ -203,7 +203,7 @@ class HearingControllerTest : TestControllerBase() {
       val body = objectMapper.writeValueAsString(hearing)
       return mockMvc
         .perform(
-          MockMvcRequestBuilders.put("/reported-adjudications/$id/hearing")
+          MockMvcRequestBuilders.put("/reported-adjudications/$id/hearing/v2")
             .header("Content-Type", "application/json")
             .content(body)
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingControllerV1Test.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingControllerV1Test.kt
@@ -1,0 +1,214 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.reported
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.TestControllerBase
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OicHearingType
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.HearingOutcomeService
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.HearingService
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.ReferralService
+import java.time.LocalDateTime
+
+@WebMvcTest(value = [HearingController::class])
+class HearingControllerV1Test : TestControllerBase() {
+
+  @MockBean
+  lateinit var hearingService: HearingService
+
+  @MockBean
+  lateinit var hearingOutcomeService: HearingOutcomeService
+
+  @MockBean
+  lateinit var referralService: ReferralService
+
+  @Nested
+  inner class CreateHearing {
+    @BeforeEach
+    fun beforeEach() {
+      whenever(
+        hearingService.createHearingV1(
+          ArgumentMatchers.anyLong(),
+          ArgumentMatchers.anyLong(),
+          any(),
+          any(),
+        )
+      ).thenReturn(REPORTED_ADJUDICATION_DTO)
+    }
+
+    @Test
+    fun `responds with a unauthorised status code`() {
+      createHearingRequest(
+        1,
+        HEARING_REQUEST
+      ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
+    }
+
+    @Test
+    @WithMockUser(username = "ITAG_USER", authorities = ["SCOPE_write"])
+    fun `responds with a forbidden status code for non ALO`() {
+      createHearingRequest(
+        1,
+        HEARING_REQUEST
+      ).andExpect(MockMvcResultMatchers.status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER"])
+    fun `responds with a forbidden status code for ALO without write scope`() {
+      createHearingRequest(
+        1,
+        HEARING_REQUEST
+      ).andExpect(MockMvcResultMatchers.status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER", "SCOPE_write"])
+    fun `makes a call to create a hearing`() {
+      createHearingRequest(1, HEARING_REQUEST)
+        .andExpect(MockMvcResultMatchers.status().isCreated)
+      verify(hearingService).createHearingV1(1, HEARING_REQUEST.locationId, HEARING_REQUEST.dateTimeOfHearing, HEARING_REQUEST.oicHearingType)
+    }
+
+    private fun createHearingRequest(
+      id: Long,
+      hearing: HearingRequest?
+    ): ResultActions {
+      val body = objectMapper.writeValueAsString(hearing)
+      return mockMvc
+        .perform(
+          MockMvcRequestBuilders.post("/reported-adjudications/$id/hearing")
+            .header("Content-Type", "application/json")
+            .content(body)
+        )
+    }
+  }
+
+  @Nested
+  inner class DeleteHearing {
+
+    @BeforeEach
+    fun beforeEach() {
+      whenever(
+        hearingService.deleteHearingV1(
+          ArgumentMatchers.anyLong(),
+          ArgumentMatchers.anyLong(),
+        )
+      ).thenReturn(REPORTED_ADJUDICATION_DTO)
+    }
+
+    @Test
+    fun `responds with a unauthorised status code`() {
+      deleteHearingRequest(1, 1).andExpect(MockMvcResultMatchers.status().isUnauthorized)
+    }
+
+    @Test
+    @WithMockUser(username = "ITAG_USER", authorities = ["SCOPE_write"])
+    fun `responds with a forbidden status code for non ALO`() {
+      deleteHearingRequest(1, 1).andExpect(MockMvcResultMatchers.status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER"])
+    fun `responds with a forbidden status code for ALO without write scope`() {
+      deleteHearingRequest(1, 1).andExpect(MockMvcResultMatchers.status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER", "SCOPE_write"])
+    fun `makes a call to delete a hearing`() {
+      deleteHearingRequest(1, 1)
+        .andExpect(MockMvcResultMatchers.status().isOk)
+      verify(hearingService).deleteHearingV1(1, 1)
+    }
+
+    private fun deleteHearingRequest(
+      id: Long,
+      hearingId: Long
+    ): ResultActions {
+      return mockMvc
+        .perform(
+          MockMvcRequestBuilders.delete("/reported-adjudications/$id/hearing/$hearingId")
+            .header("Content-Type", "application/json")
+        )
+    }
+  }
+
+  @Nested
+  inner class AmendHearing {
+    @BeforeEach
+    fun beforeEach() {
+      whenever(
+        hearingService.amendHearingV1(
+          ArgumentMatchers.anyLong(),
+          ArgumentMatchers.anyLong(),
+          ArgumentMatchers.anyLong(),
+          any(),
+          any(),
+        )
+      ).thenReturn(REPORTED_ADJUDICATION_DTO)
+    }
+
+    @Test
+    fun `responds with a unauthorised status code`() {
+      amendHearingRequest(
+        1, 1,
+        HEARING_REQUEST
+      ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
+    }
+
+    @Test
+    @WithMockUser(username = "ITAG_USER", authorities = ["SCOPE_write"])
+    fun `responds with a forbidden status code for non ALO`() {
+      amendHearingRequest(
+        1, 1,
+        HEARING_REQUEST
+      ).andExpect(MockMvcResultMatchers.status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER"])
+    fun `responds with a forbidden status code for ALO without write scope`() {
+      amendHearingRequest(
+        1, 1,
+        HEARING_REQUEST
+      ).andExpect(MockMvcResultMatchers.status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER", "SCOPE_write"])
+    fun `makes a call to amend a hearing`() {
+      amendHearingRequest(1, 1, HEARING_REQUEST)
+        .andExpect(MockMvcResultMatchers.status().isOk)
+      verify(hearingService).amendHearingV1(1, 1, HEARING_REQUEST.locationId, HEARING_REQUEST.dateTimeOfHearing, HEARING_REQUEST.oicHearingType)
+    }
+
+    private fun amendHearingRequest(
+      id: Long,
+      hearingId: Long,
+      hearing: HearingRequest?
+    ): ResultActions {
+      val body = objectMapper.writeValueAsString(hearing)
+      return mockMvc
+        .perform(
+          MockMvcRequestBuilders.put("/reported-adjudications/$id/hearing/$hearingId")
+            .header("Content-Type", "application/json")
+            .content(body)
+        )
+    }
+  }
+
+  companion object {
+    private val HEARING_REQUEST = HearingRequest(locationId = 1L, dateTimeOfHearing = LocalDateTime.now(), oicHearingType = OicHearingType.GOV)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
@@ -26,7 +26,7 @@ class HearingsIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
     webTestClient.post()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/v2")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
@@ -56,7 +56,7 @@ class HearingsIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
     webTestClient.post()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/v2")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
@@ -78,7 +78,7 @@ class HearingsIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingFailure(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
     webTestClient.post()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/v2")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
@@ -108,7 +108,7 @@ class HearingsIntTest : IntegrationTestBase() {
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 25, 10, 0)
 
     webTestClient.put()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/v2")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
@@ -139,7 +139,7 @@ class HearingsIntTest : IntegrationTestBase() {
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 25, 10, 0)
 
     webTestClient.put()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/v2")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
@@ -161,7 +161,7 @@ class HearingsIntTest : IntegrationTestBase() {
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 25, 10, 0)
 
     webTestClient.put()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/v2")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(
@@ -193,7 +193,7 @@ class HearingsIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
 
     webTestClient.delete()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/v2")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .exchange()
       .expectStatus().isOk
@@ -211,7 +211,7 @@ class HearingsIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubDeleteHearingFailure(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
 
     webTestClient.delete()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/v2")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .exchange()
       .expectStatus().is5xxServerError

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsV1IntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsV1IntTest.kt
@@ -1,0 +1,280 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.reported.ReportedAdjudicationResponse
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OicHearingType
+import java.time.LocalDateTime
+
+class HearingsV1IntTest : IntegrationTestBase() {
+
+  @BeforeEach
+  fun setUp() {
+    setAuditTime(IntegrationTestData.DEFAULT_REPORTED_DATE_TIME)
+  }
+
+  @Test
+  fun `create a hearing `() {
+    initDataForHearingsV1()
+
+    val dateTimeOfHearing = LocalDateTime.of(2010, 10, 12, 10, 0)
+    prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+
+    webTestClient.post()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .bodyValue(
+        mapOf(
+          "locationId" to 1,
+          "dateTimeOfHearing" to dateTimeOfHearing,
+          "oicHearingType" to OicHearingType.GOV.name,
+        )
+      )
+      .exchange()
+      .expectStatus().isCreated
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.status")
+      .isEqualTo(ReportedAdjudicationStatus.SCHEDULED.name)
+      .jsonPath("$.reportedAdjudication.hearings[0].locationId")
+      .isEqualTo(1)
+      .jsonPath("$.reportedAdjudication.hearings[0].dateTimeOfHearing")
+      .isEqualTo("2010-10-12T10:00:00")
+      .jsonPath("$.reportedAdjudication.hearings[0].id").isNotEmpty
+      .jsonPath("$.reportedAdjudication.hearings[0].oicHearingType").isEqualTo(OicHearingType.GOV.name)
+  }
+
+  @Test
+  fun `create a hearing illegal state on hearing type `() {
+    initDataForHearingsV1()
+
+    val dateTimeOfHearing = LocalDateTime.of(2010, 10, 12, 10, 0)
+    prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+
+    webTestClient.post()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .bodyValue(
+        mapOf(
+          "locationId" to 1,
+          "dateTimeOfHearing" to dateTimeOfHearing,
+          "oicHearingType" to OicHearingType.GOV_YOI.name,
+        )
+      )
+      .exchange()
+      .expectStatus().isBadRequest
+  }
+
+  @Test
+  fun `create hearing fails on prisonApi and does not create a hearing`() {
+    initDataForHearingsV1()
+
+    val dateTimeOfHearing = LocalDateTime.of(2010, 10, 12, 10, 0)
+
+    prisonApiMockServer.stubCreateHearingFailure(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+
+    webTestClient.post()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .bodyValue(
+        mapOf(
+          "locationId" to 1,
+          "dateTimeOfHearing" to dateTimeOfHearing,
+          "oicHearingType" to OicHearingType.GOV.name,
+        )
+      )
+      .exchange()
+      .expectStatus().is5xxServerError
+
+    webTestClient.get()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}")
+      .headers(setHeaders())
+      .exchange()
+      .expectStatus().is2xxSuccessful
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.hearings.size()").isEqualTo(0)
+  }
+
+  @Test
+  fun `amend a hearing `() {
+    initDataForHearingsV1()
+    val reportedAdjudication = createHearing()
+
+    prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
+    val dateTimeOfHearing = LocalDateTime.of(2010, 10, 25, 10, 0)
+
+    webTestClient.put()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/${reportedAdjudication.reportedAdjudication.hearings.first().id}")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .bodyValue(
+        mapOf(
+          "locationId" to 3,
+          "dateTimeOfHearing" to dateTimeOfHearing.plusDays(1),
+          "oicHearingType" to OicHearingType.GOV_ADULT.name,
+        )
+      )
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.status")
+      .isEqualTo(ReportedAdjudicationStatus.SCHEDULED.name)
+      .jsonPath("$.reportedAdjudication.hearings[0].locationId")
+      .isEqualTo(3)
+      .jsonPath("$.reportedAdjudication.hearings[0].dateTimeOfHearing")
+      .isEqualTo("2010-10-26T10:00:00")
+      .jsonPath("$.reportedAdjudication.hearings[0].id").isNotEmpty
+      .jsonPath("$.reportedAdjudication.hearings[0].oicHearingType").isEqualTo(OicHearingType.GOV_ADULT.name)
+  }
+
+  @Test
+  fun `amend a hearing illegal state on hearing type `() {
+    initDataForHearingsV1()
+    val reportedAdjudication = createHearing()
+
+    prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
+    val dateTimeOfHearing = LocalDateTime.of(2010, 10, 25, 10, 0)
+
+    webTestClient.put()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/${reportedAdjudication.reportedAdjudication.hearings.first().id}")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .bodyValue(
+        mapOf(
+          "locationId" to 3,
+          "dateTimeOfHearing" to dateTimeOfHearing.plusDays(1),
+          "oicHearingType" to OicHearingType.GOV_YOI.name,
+        )
+      )
+      .exchange()
+      .expectStatus().isBadRequest
+  }
+
+  @Test
+  fun `amend a hearing fails on prison api and does not update the hearing `() {
+    initDataForHearingsV1()
+    val reportedAdjudication = createHearing()
+
+    prisonApiMockServer.stubAmendHearingFailure(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
+    val dateTimeOfHearing = LocalDateTime.of(2010, 10, 25, 10, 0)
+
+    webTestClient.put()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/${reportedAdjudication.reportedAdjudication.hearings.first().id}")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .bodyValue(
+        mapOf(
+          "locationId" to 3,
+          "dateTimeOfHearing" to dateTimeOfHearing.plusDays(1),
+          "oicHearingType" to OicHearingType.GOV_ADULT.name,
+        )
+      )
+      .exchange()
+      .expectStatus().is5xxServerError
+
+    webTestClient.get()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}")
+      .headers(setHeaders())
+      .exchange()
+      .expectStatus().is2xxSuccessful
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.hearings[0].locationId")
+      .isEqualTo(IntegrationTestData.UPDATED_LOCATION_ID)
+      .jsonPath("$.reportedAdjudication.hearings[0].dateTimeOfHearing")
+      .isEqualTo("2010-11-19T10:00:00")
+      .jsonPath("$.reportedAdjudication.hearings[0].id").isNotEmpty
+  }
+
+  @Test
+  fun `delete a hearing `() {
+    initDataForHearingsV1()
+    val reportedAdjudication = createHearing()
+
+    prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
+
+    assert(reportedAdjudication.reportedAdjudication.hearings.size == 1)
+
+    webTestClient.delete()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/${reportedAdjudication.reportedAdjudication.hearings.first().id!!}")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.status")
+      .isEqualTo(ReportedAdjudicationStatus.UNSCHEDULED.name)
+      .jsonPath("$.reportedAdjudication.hearings.size()").isEqualTo(0)
+  }
+
+  @Test
+  fun `delete a hearing fails on prison api and does not delete record`() {
+    initDataForHearingsV1()
+    val reportedAdjudication = createHearing()
+
+    prisonApiMockServer.stubDeleteHearingFailure(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
+
+    assert(reportedAdjudication.reportedAdjudication.hearings.size == 1)
+
+    webTestClient.delete()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/${reportedAdjudication.reportedAdjudication.hearings.first().id!!}")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .exchange()
+      .expectStatus().is5xxServerError
+
+    webTestClient.get()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}")
+      .headers(setHeaders())
+      .exchange()
+      .expectStatus().is2xxSuccessful
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.hearings.size()").isEqualTo(1)
+  }
+
+  private fun initDataForHearingsV1(): IntegrationTestData {
+    val intTestData = integrationTestData()
+    val draftUserHeaders = setHeaders(username = IntegrationTestData.DEFAULT_ADJUDICATION.createdByUserId)
+    val draftIntTestScenarioBuilder = IntegrationTestScenarioBuilder(intTestData, this, draftUserHeaders)
+
+    draftIntTestScenarioBuilder
+      .startDraft(IntegrationTestData.DEFAULT_ADJUDICATION)
+      .setApplicableRules()
+      .setIncidentRole()
+      .setOffenceData()
+      .addIncidentStatement()
+      .addDamages()
+      .addEvidence()
+      .addWitnesses()
+      .completeDraft()
+
+    return intTestData
+  }
+
+  fun createHearing(): ReportedAdjudicationResponse {
+    prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    val intTestData = integrationTestData()
+
+    return createHearing(
+      IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber,
+      IntegrationTestData.DEFAULT_ADJUDICATION,
+      setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER"))
+    )
+  }
+
+  fun createHearing(
+    adjudicationNumber: Long,
+    testDataSet: AdjudicationIntTestDataSet,
+    headers: (HttpHeaders) -> Unit = setHeaders()
+  ): ReportedAdjudicationResponse {
+    return webTestClient.post()
+      .uri("/reported-adjudications/$adjudicationNumber/hearing")
+      .headers(headers)
+      .bodyValue(
+        mapOf(
+          "locationId" to testDataSet.locationId,
+          "dateTimeOfHearing" to testDataSet.dateTimeOfHearing!!,
+          "oicHearingType" to OicHearingType.GOV.name,
+        )
+      )
+      .exchange()
+      .returnResult(ReportedAdjudicationResponse::class.java)
+      .responseBody
+      .blockFirst()!!
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
@@ -557,7 +557,7 @@ class IntegrationTestData(
     oicHearingType: OicHearingType? = OicHearingType.GOV
   ): WebTestClient.ResponseSpec {
     return webTestClient.post()
-      .uri("/reported-adjudications/${testDataSet.adjudicationNumber}/hearing")
+      .uri("/reported-adjudications/${testDataSet.adjudicationNumber}/hearing/v2")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .bodyValue(
         mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
@@ -37,6 +37,22 @@ class OutcomeIntTest : IntegrationTestBase() {
       .jsonPath("$.reportedAdjudication.outcomes[0].outcome.code").isEqualTo(OutcomeCode.NOT_PROCEED.name)
   }
 
+  @Test
+  fun `refer to police leads to police prosecution`() {
+    initDataForOutcome().createOutcome()
+
+    integrationTestData().createOutcome(
+      IntegrationTestData.DEFAULT_ADJUDICATION, OutcomeCode.PROSECUTION
+    ).expectStatus().isCreated
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.history.size()").isEqualTo(1)
+      .jsonPath("$.reportedAdjudication.history[0].outcome.referralOutcome").exists()
+      .jsonPath("$.reportedAdjudication.history[0].outcome.outcome.code").isEqualTo(OutcomeCode.REFER_POLICE.name)
+      .jsonPath("$.reportedAdjudication.history[0].outcome.referralOutcome.code").isEqualTo(OutcomeCode.PROSECUTION.name)
+      .jsonPath("$.reportedAdjudication.status").isEqualTo(ReportedAdjudicationStatus.PROSECUTION.name)
+      .jsonPath("$.reportedAdjudication.hearings.size()").isEqualTo(0)
+  }
+
   protected fun initDataForOutcome(): IntegrationTestScenario {
     prisonApiMockServer.stubPostAdjudication(IntegrationTestData.DEFAULT_ADJUDICATION)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReferralsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReferralsIntTest.kt
@@ -191,7 +191,7 @@ class ReferralsIntTest : OutcomeIntTest() {
     prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
 
     webTestClient.delete()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/v2")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .exchange()
       .expectStatus().isOk
@@ -226,7 +226,7 @@ class ReferralsIntTest : OutcomeIntTest() {
     prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber, 100)
 
     webTestClient.delete()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing")
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/v2")
       .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
       .exchange()
       .expectStatus().isOk


### PR DESCRIPTION
restoring old hearings create / amend / delete and setting old code as v1 (and test files) to remove at some point.
New endpoints v2 for now, but named as current code.