### PR TITLE
NN-4876

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeController.kt
@@ -61,4 +61,17 @@ class OutcomeController(
 
     return ReportedAdjudicationResponse(reportedAdjudication)
   }
+
+  @Operation(summary = "remove an outcome")
+  @DeleteMapping(value = ["/{adjudicationNumber}/outcome"])
+  @ResponseStatus(HttpStatus.OK)
+  fun removeOutcome(
+    @PathVariable(name = "adjudicationNumber") adjudicationNumber: Long,
+  ): ReportedAdjudicationResponse {
+    val reportedAdjudication = outcomeService.deleteOutcome(
+      adjudicationNumber = adjudicationNumber,
+    )
+
+    return ReportedAdjudicationResponse(reportedAdjudication)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/Outcome.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/Outcome.kt
@@ -40,6 +40,10 @@ enum class OutcomeCode(val status: ReportedAdjudicationStatus) {
     val from = this
     return from.nextStates().contains(to)
   }
+
+  companion object {
+    fun referrals() = listOf(REFER_POLICE, REFER_INAD)
+  }
 }
 
 enum class NotProceedReason {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingService.kt
@@ -190,7 +190,7 @@ class HearingService(
 
   fun deleteHearing(adjudicationNumber: Long): ReportedAdjudicationDto {
     val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber)
-    val hearingToRemove = reportedAdjudication.getHearing()
+    val hearingToRemove = reportedAdjudication.getHearing().canDelete()
 
     if (reportedAdjudication.lastOutcomeIsScheduleHearing())
       reportedAdjudication.outcomes.removeLast()
@@ -255,6 +255,11 @@ class HearingService(
     fun ReportedAdjudication.getHearing(): Hearing = this.getLatestHearing() ?: throwHearingNotFoundException()
 
     fun ReportedAdjudication.calcFirstHearingDate(): LocalDateTime? = this.hearings.minOfOrNull { it.dateTimeOfHearing }
+
+    fun Hearing.canDelete(): Hearing {
+      if (OutcomeCode.referrals().contains(this.hearingOutcome?.code?.outcomeCode)) throw ValidationException("Unable to delete hearing via api DEL/hearing - referral associated to this hearing")
+      return this
+    }
 
     private fun throwHearingNotFoundException(): Nothing = throw EntityNotFoundException("Hearing not found")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingService.kt
@@ -257,7 +257,8 @@ class HearingService(
     fun ReportedAdjudication.calcFirstHearingDate(): LocalDateTime? = this.hearings.minOfOrNull { it.dateTimeOfHearing }
 
     fun Hearing.canDelete(): Hearing {
-      if (OutcomeCode.referrals().contains(this.hearingOutcome?.code?.outcomeCode)) throw ValidationException("Unable to delete hearing via api DEL/hearing - referral associated to this hearing")
+      if (OutcomeCode.referrals().contains(this.hearingOutcome?.code?.outcomeCode))
+        throw ValidationException("Unable to delete hearing via api DEL/hearing - referral associated to this hearing")
       return this
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
@@ -40,7 +40,7 @@ class OutcomeService(
     }
 
     if (reportedAdjudication.lastOutcomeIsRefer())
-      reportedAdjudication.outcomes.maxBy { it.createDateTime!! }.code.validateReferral(code)
+      reportedAdjudication.latestOutcome()!!.code.validateReferral(code)
 
     when (code) {
       OutcomeCode.REFER_POLICE, OutcomeCode.REFER_INAD -> validateDetails(details)
@@ -63,9 +63,9 @@ class OutcomeService(
     return saveToDto(reportedAdjudication)
   }
 
-  fun deleteOutcome(adjudicationNumber: Long, id: Long): ReportedAdjudicationDto {
+  fun deleteOutcome(adjudicationNumber: Long, id: Long? = null): ReportedAdjudicationDto {
     val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber)
-    val outcomeToDelete = reportedAdjudication.getOutcome(id)
+    val outcomeToDelete = reportedAdjudication.getOutcome(id!!)
 
     reportedAdjudication.outcomes.remove(outcomeToDelete)
     reportedAdjudication.calculateStatus()
@@ -91,6 +91,7 @@ class OutcomeService(
   companion object {
     private fun validateDetails(details: String?) = details ?: throw ValidationException("details are required")
 
+    fun ReportedAdjudication.latestOutcome(): Outcome? = this.outcomes.maxByOrNull { it.createDateTime!! }
     fun ReportedAdjudication.getReferral(code: OutcomeCode) =
       this.outcomes.filter { it.code == code }.sortedByDescending { it.createDateTime }.firstOrNull()
         ?: throw EntityNotFoundException("Referral not found for ${this.reportNumber}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
@@ -109,7 +109,7 @@ class OutcomeService(
     }
 
     fun Outcome.canDelete(): Outcome {
-      if (OutcomeCode.referrals().contains(this.code)) throw ValidationException("Unable to delete referral via api - DEL/outcome")
+      if (OutcomeCode.referrals().contains(this.code) || this.code == OutcomeCode.SCHEDULE_HEARING) throw ValidationException("Unable to delete referral via api - DEL/outcome")
       return this
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReferralService.kt
@@ -76,8 +76,7 @@ class ReferralService(
 
   companion object {
     fun List<CombinedOutcomeDto>.validateHasReferral(): List<CombinedOutcomeDto> {
-      val referrals = listOf(OutcomeCode.REFER_POLICE, OutcomeCode.REFER_INAD)
-      if (this.none { referrals.contains(it.outcome.code) }) throw ValidationException("No referral for adjudication")
+      if (this.none { OutcomeCode.referrals().contains(it.outcome.code) }) throw ValidationException("No referral for adjudication")
 
       return this
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeControllerTest.kt
@@ -124,7 +124,7 @@ class OutcomeControllerTest : TestControllerBase() {
 
     @Test
     @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER", "SCOPE_write"])
-    fun `makes a call to reemove a referral`() {
+    fun `makes a call to remove a referral`() {
       removeReferralRequest(1,)
         .andExpect(MockMvcResultMatchers.status().isOk)
       verify(referralService).removeReferral(1,)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeControllerTest.kt
@@ -148,6 +148,7 @@ class OutcomeControllerTest : TestControllerBase() {
       whenever(
         outcomeService.deleteOutcome(
           anyLong(),
+          anyOrNull(),
         )
       ).thenReturn(REPORTED_ADJUDICATION_DTO)
     }
@@ -180,9 +181,8 @@ class OutcomeControllerTest : TestControllerBase() {
     fun `makes a call to delete an outcome`() {
       deleteOutcomeRequest(1)
         .andExpect(MockMvcResultMatchers.status().isOk)
-      verify(outcomeService).createOutcome(
+      verify(outcomeService).deleteOutcome(
         1,
-        OutcomeCode.REFER_POLICE,
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestScenarioBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestScenarioBuilder.kt
@@ -4,6 +4,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.draft.DraftAdjudicationResponse
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.NotProceedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 
@@ -98,9 +99,10 @@ class IntegrationTestScenario(
   }
 
   fun createOutcome(
-    code: OutcomeCode? = OutcomeCode.REFER_POLICE
+    code: OutcomeCode? = OutcomeCode.REFER_POLICE,
+    reason: NotProceedReason? = null,
   ): WebTestClient.ResponseSpec {
-    return intTestData.createOutcome(testAdjudicationDataSet, code)
+    return intTestData.createOutcome(testAdjudicationDataSet, code, reason)
   }
 
   fun issueReport(reportNumber: String): IntegrationTestScenario {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
@@ -39,7 +39,7 @@ class OutcomeIntTest : IntegrationTestBase() {
 
   @Test
   fun `delete an outcome - not proceed `() {
-    initDataForOutcome().createOutcome(code = OutcomeCode.NOT_PROCEED)
+    initDataForOutcome().createOutcome(code = OutcomeCode.NOT_PROCEED, reason = NotProceedReason.NOT_FAIR).expectStatus().isCreated
 
     webTestClient.delete()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/outcome")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
@@ -38,6 +38,22 @@ class OutcomeIntTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `delete an outcome - not proceed `() {
+    initDataForOutcome().createOutcome(code = OutcomeCode.NOT_PROCEED)
+
+    webTestClient.delete()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/outcome")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.history.size()")
+      .isEqualTo(0)
+      .jsonPath("$.reportedAdjudication.outcomes.size()")
+      .isEqualTo(0)
+  }
+
+  @Test
   fun `refer to police leads to police prosecution`() {
     initDataForOutcome().createOutcome()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
@@ -245,7 +245,7 @@ class OutcomeServiceTest : ReportedAdjudicationTestBase() {
     }
 
     @ParameterizedTest
-    @CsvSource("REFER_POLICE", "REFER_INAD", "SCHEDULE_HEARING")
+    @CsvSource("REFER_POLICE", "REFER_INAD", "SCHEDULE_HEARING", "PROSECUTION", "NOT_PROCEED")
     fun `throws invalid state if delete latest outcome is invalid type `(code: OutcomeCode) {
       whenever(reportedAdjudicationRepository.findByReportNumber(1)).thenReturn(
         reportedAdjudication
@@ -257,7 +257,7 @@ class OutcomeServiceTest : ReportedAdjudicationTestBase() {
       Assertions.assertThatThrownBy {
         outcomeService.deleteOutcome(1,)
       }.isInstanceOf(ValidationException::class.java)
-        .hasMessageContaining("Unable to delete referral via api - DEL/outcome")
+        .hasMessageContaining("Unable to delete via api - DEL/outcome")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
@@ -245,7 +245,7 @@ class OutcomeServiceTest : ReportedAdjudicationTestBase() {
     }
 
     @ParameterizedTest
-    @CsvSource("REFER_POLICE", "REFER_INAD")
+    @CsvSource("REFER_POLICE", "REFER_INAD", "SCHEDULE_HEARING")
     fun `throws invalid state if delete latest outcome is invalid type `(code: OutcomeCode) {
       whenever(reportedAdjudicationRepository.findByReportNumber(1)).thenReturn(
         reportedAdjudication

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
@@ -227,6 +227,29 @@ class OutcomeServiceTest : ReportedAdjudicationTestBase() {
       }.isInstanceOf(EntityNotFoundException::class.java)
         .hasMessageContaining("Outcome not found for 1")
     }
+
+    @Test
+    fun `delete latest outcome throws not found if no outcomes present `() {
+      Assertions.assertThatThrownBy {
+        outcomeService.deleteOutcome(1,)
+      }.isInstanceOf(EntityNotFoundException::class.java)
+        .hasMessageContaining("Outcome not found for 1")
+    }
+
+    @Test
+    fun `delete latest outcome succeeds`() {
+      val argumentCaptor = ArgumentCaptor.forClass(ReportedAdjudication::class.java)
+
+      val response = outcomeService.deleteOutcome(
+        3,
+      )
+      verify(reportedAdjudicationRepository).save(argumentCaptor.capture())
+
+      assertThat(argumentCaptor.value.outcomes).isEmpty()
+      assertThat(argumentCaptor.value.status).isEqualTo(ReportedAdjudicationStatus.UNSCHEDULED)
+
+      assertThat(response).isNotNull
+    }
   }
 
   @Nested


### PR DESCRIPTION
delete outcome

-  api call does not take an id, and deletes latest
- referrals can not use this api call, and will be rejected (ie when we have no id)
- referrals can use this method via the referral service, when explicitly providing the ID
- add further checks to ensure delete hearing is not available for referral outcomes
- not proceed can only use delete via the api if no hearings, as not proceed (with hearings) for now would be a referral outcome

Completed path provides a not proceed option (via hearing) which would need to be addressed here, given the status is most likely completed - finding Not proceed.  Will be addressed when we implement this path

Question likely directed to Simon, ie should "completed - not proceed" be a not proceed outcome
