### PR TITLE
NN-4912

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingController.kt
@@ -207,4 +207,14 @@ class HearingController(
 
     return ReportedAdjudicationResponse(reportedAdjudication)
   }
+
+  @DeleteMapping(value = ["/{adjudicationNumber}/hearing/outcome/adjourn"])
+  @Operation(summary = "removes the adjourn outcome")
+  @ResponseStatus(HttpStatus.OK)
+  fun removeAdjourn(
+    @PathVariable(name = "adjudicationNumber") adjudicationNumber: Long,
+  ): ReportedAdjudicationResponse {
+    val reportedAdjudication = hearingOutcomeService.removeAdjourn(adjudicationNumber = adjudicationNumber)
+    return ReportedAdjudicationResponse(reportedAdjudication)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeController.kt
@@ -73,7 +73,7 @@ class OutcomeController(
   private val completedHearingService: CompletedHearingService,
 ) : ReportedAdjudicationBaseController() {
 
-  @Operation(summary = "create a not proceed outcome")
+  @Operation(summary = "create a not proceed outcome - via referral or without hearing")
   @PostMapping(value = ["/{adjudicationNumber}/outcome/not-proceed"])
   @ResponseStatus(HttpStatus.CREATED)
   fun createNotProceed(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeController.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomePlea
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.NotProceedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.QuashedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.CompletedHearingService
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.OutcomeService
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.ReferralService
@@ -63,6 +64,14 @@ data class HearingCompletedChargeProvedRequest(
   val amount: Double? = null,
   @Schema(description = "is this a caution")
   val caution: Boolean,
+)
+
+@Schema(description = "Request to quash charge")
+data class QuashedRequest(
+  @Schema(description = "details")
+  val details: String,
+  @Schema(description = "reason")
+  val reason: QuashedReason,
 )
 
 @PreAuthorize("hasRole('ADJUDICATIONS_REVIEWER') and hasAuthority('SCOPE_write')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeController.kt
@@ -111,6 +111,22 @@ class OutcomeController(
     return ReportedAdjudicationResponse(reportedAdjudication)
   }
 
+  @Operation(summary = "quash an outcome")
+  @PostMapping(value = ["/{adjudicationNumber}/outcome/quashed"])
+  @ResponseStatus(HttpStatus.CREATED)
+  fun createQuashed(
+    @PathVariable(name = "adjudicationNumber") adjudicationNumber: Long,
+    @RequestBody quashedRequest: QuashedRequest
+  ): ReportedAdjudicationResponse {
+    val reportedAdjudication = outcomeService.createQuashed(
+      adjudicationNumber = adjudicationNumber,
+      reason = quashedRequest.reason,
+      details = quashedRequest.details,
+    )
+
+    return ReportedAdjudicationResponse(reportedAdjudication)
+  }
+
   @Operation(summary = "create a police refer outcome")
   @PostMapping(value = ["/{adjudicationNumber}/outcome/refer-police"])
   @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeController.kt
@@ -209,10 +209,10 @@ class OutcomeController(
     return ReportedAdjudicationResponse(reportedAdjudication)
   }
 
-  @Operation(summary = "remove a not proceed without a referral or hearing")
-  @DeleteMapping(value = ["/{adjudicationNumber}/outcome/not-proceed"])
+  @Operation(summary = "remove a not proceed without a referral or hearing, or a quashed outcome")
+  @DeleteMapping(value = ["/{adjudicationNumber}/outcome"])
   @ResponseStatus(HttpStatus.OK)
-  fun removeNotProceedWithoutReferral(
+  fun removeNotProceedWithoutReferralOrQuashed(
     @PathVariable(name = "adjudicationNumber") adjudicationNumber: Long,
   ): ReportedAdjudicationResponse {
     val reportedAdjudication = outcomeService.deleteOutcome(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/ReportedAdjudicationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/ReportedAdjudicationDto.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Hearing
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomePlea
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.NotProceedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.QuashedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.WitnessCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OicHearingType
@@ -190,6 +191,8 @@ data class OutcomeDto(
   val amount: Double? = null,
   @Schema(description = "optional is this outcome a caution")
   val caution: Boolean? = null,
+  @Schema(description = "optional quashed reason")
+  val quashedReason: QuashedReason? = null,
 )
 
 @Schema(description = "Combined Outcome - currently to support referral but maybe expanded once awards are added")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/Outcome.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/Outcome.kt
@@ -19,6 +19,8 @@ data class Outcome(
   var code: OutcomeCode,
   var amount: Double? = null,
   var caution: Boolean? = null,
+  @Enumerated(EnumType.STRING)
+  var quashedReason: QuashedReason? = null,
 ) : BaseEntity()
 
 enum class OutcomeCode(val status: ReportedAdjudicationStatus) {
@@ -36,7 +38,8 @@ enum class OutcomeCode(val status: ReportedAdjudicationStatus) {
   DISMISSED(ReportedAdjudicationStatus.DISMISSED),
   PROSECUTION(ReportedAdjudicationStatus.PROSECUTION),
   SCHEDULE_HEARING(ReportedAdjudicationStatus.SCHEDULED),
-  CHARGE_PROVED(ReportedAdjudicationStatus.CHARGE_PROVED);
+  CHARGE_PROVED(ReportedAdjudicationStatus.CHARGE_PROVED),
+  QUASHED(ReportedAdjudicationStatus.QUASHED);
 
   fun validateReferral(): OutcomeCode {
     if (referrals().none { this == it }) throw ValidationException("invalid referral type")
@@ -58,4 +61,8 @@ enum class OutcomeCode(val status: ReportedAdjudicationStatus) {
 
 enum class NotProceedReason {
   ANOTHER_WAY, RELEASED, WITNESS_NOT_ATTEND, UNFIT, FLAWED, EXPIRED_NOTICE, EXPIRED_HEARING, NOT_FAIR, OTHER
+}
+
+enum class QuashedReason {
+  FLAWED_CASE, JUDICIAL_REVIEW, APPEAL_UPHELD
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
@@ -128,9 +128,22 @@ enum class ReportedAdjudicationStatus {
     }
   },
   PROSECUTION,
-  DISMISSED,
-  NOT_PROCEED,
-  CHARGE_PROVED;
+  DISMISSED {
+    override fun nextStates(): List<ReportedAdjudicationStatus> {
+      return listOf(QUASHED)
+    }
+  },
+  NOT_PROCEED {
+    override fun nextStates(): List<ReportedAdjudicationStatus> {
+      return listOf(QUASHED)
+    }
+  },
+  CHARGE_PROVED {
+    override fun nextStates(): List<ReportedAdjudicationStatus> {
+      return listOf(QUASHED)
+    }
+  },
+  QUASHED;
   open fun nextStates(): List<ReportedAdjudicationStatus> = listOf()
   fun canTransitionFrom(from: ReportedAdjudicationStatus): Boolean {
     val to = this

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
@@ -128,16 +128,8 @@ enum class ReportedAdjudicationStatus {
     }
   },
   PROSECUTION,
-  DISMISSED {
-    override fun nextStates(): List<ReportedAdjudicationStatus> {
-      return listOf(QUASHED)
-    }
-  },
-  NOT_PROCEED {
-    override fun nextStates(): List<ReportedAdjudicationStatus> {
-      return listOf(QUASHED)
-    }
-  },
+  DISMISSED,
+  NOT_PROCEED,
   CHARGE_PROVED {
     override fun nextStates(): List<ReportedAdjudicationStatus> {
       return listOf(QUASHED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingOutcomeService.kt
@@ -65,6 +65,12 @@ class HearingOutcomeService(
     plea = plea
   )
 
+  fun removeAdjourn(
+    adjudicationNumber: Long
+  ): ReportedAdjudicationDto {
+    TODO("implement me")
+  }
+
   private fun createHearingOutcome(
     adjudicationNumber: Long,
     code: HearingOutcomeCode,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
@@ -157,7 +157,7 @@ class OutcomeService(
     }
 
     fun Outcome.canDelete(hasHearings: Boolean): Outcome {
-      val acceptableItems = if (!hasHearings) listOf(OutcomeCode.NOT_PROCEED) else emptyList()
+      val acceptableItems = if (!hasHearings) listOf(OutcomeCode.NOT_PROCEED) else listOf(OutcomeCode.QUASHED)
       if (acceptableItems.none { it == this.code }) throw ValidationException("Unable to delete via api - DEL/outcome")
 
       return this

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.ReportedAdj
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.NotProceedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Outcome
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.QuashedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudication
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus.Companion.validateTransition
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
@@ -74,6 +75,14 @@ class OutcomeService(
     amount = amount,
     caution = caution
   )
+
+  fun createQuashed(
+    adjudicationNumber: Long,
+    reason: QuashedReason,
+    details: String,
+  ): ReportedAdjudicationDto {
+    TODO("implement me")
+  }
 
   private fun createOutcome(
     adjudicationNumber: Long,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
@@ -3,8 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.report
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.CombinedOutcomeDto
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.ReportedAdjudicationDto
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcome
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.NotProceedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Outcome
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
@@ -14,7 +12,6 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Reporte
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.OffenceCodeLookupService
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.HearingService.Companion.getHearing
 import javax.persistence.EntityNotFoundException
 import javax.transaction.Transactional
 import javax.validation.ValidationException
@@ -84,7 +81,7 @@ class OutcomeService(
     reason: QuashedReason,
     details: String,
   ): ReportedAdjudicationDto {
-    findByAdjudicationNumber(adjudicationNumber).getHearing().hearingOutcome.canQuash()
+    findByAdjudicationNumber(adjudicationNumber).latestOutcome().canQuash()
 
     return createOutcome(
       adjudicationNumber = adjudicationNumber,
@@ -166,8 +163,8 @@ class OutcomeService(
     fun ReportedAdjudication.lastOutcomeIsRefer() =
       OutcomeCode.referrals().contains(this.outcomes.maxByOrNull { it.createDateTime!! }?.code)
 
-    fun HearingOutcome?.canQuash() {
-      if (this?.code != HearingOutcomeCode.COMPLETE)
+    fun Outcome?.canQuash() {
+      if (this?.code != OutcomeCode.CHARGE_PROVED)
         throw ValidationException("unable to quash this outcome")
     }
   }

--- a/src/main/resources/db/migration/V55__add_quashed_to_outcome.sql
+++ b/src/main/resources/db/migration/V55__add_quashed_to_outcome.sql
@@ -1,0 +1,1 @@
+ALTER TABLE outcome ADD COLUMN quashed_reason varchar(32);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingControllerTest.kt
@@ -387,6 +387,54 @@ class HearingControllerTest : TestControllerBase() {
     }
   }
 
+  @Nested
+  inner class DeleteAdjourn {
+    @BeforeEach
+    fun beforeEach() {
+      whenever(
+        hearingOutcomeService.deleteHearingOutcome(
+          ArgumentMatchers.anyLong(),
+        )
+      ).thenReturn(REPORTED_ADJUDICATION_DTO)
+    }
+
+    @Test
+    fun `responds with a unauthorised status code`() {
+      deleteAdjournRequest(
+        1,
+      ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
+    }
+
+    @Test
+    @WithMockUser(username = "ITAG_USER", authorities = ["SCOPE_write"])
+    fun `responds with a forbidden status code for non ALO`() {
+      deleteAdjournRequest(
+        1,
+      ).andExpect(MockMvcResultMatchers.status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER", "SCOPE_write"])
+    fun `makes a call to delete an adjourn`() {
+      deleteAdjournRequest(1,)
+        .andExpect(MockMvcResultMatchers.status().isCreated)
+      verify(hearingOutcomeService).deleteHearingOutcome(
+        adjudicationNumber = 1,
+      )
+    }
+
+    private fun deleteAdjournRequest(
+      id: Long,
+    ): ResultActions {
+      val body = objectMapper.writeValueAsString(adjournRequest)
+      return mockMvc
+        .perform(
+          MockMvcRequestBuilders.delete("/reported-adjudications/$id/hearing/outcome/adjourn")
+            .header("Content-Type", "application/json")
+        )
+    }
+  }
+
   companion object {
     private val HEARING_REQUEST = HearingRequest(locationId = 1L, dateTimeOfHearing = LocalDateTime.now(), oicHearingType = OicHearingType.GOV)
     private fun referralRequest(code: HearingOutcomeCode? = HearingOutcomeCode.REFER_POLICE) = ReferralRequest(adjudicator = "test", code = code!!, details = "details")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingControllerTest.kt
@@ -392,7 +392,7 @@ class HearingControllerTest : TestControllerBase() {
     @BeforeEach
     fun beforeEach() {
       whenever(
-        hearingOutcomeService.deleteHearingOutcome(
+        hearingOutcomeService.removeAdjourn(
           ArgumentMatchers.anyLong(),
         )
       ).thenReturn(REPORTED_ADJUDICATION_DTO)
@@ -418,7 +418,7 @@ class HearingControllerTest : TestControllerBase() {
     fun `makes a call to delete an adjourn`() {
       deleteAdjournRequest(1,)
         .andExpect(MockMvcResultMatchers.status().isCreated)
-      verify(hearingOutcomeService).deleteHearingOutcome(
+      verify(hearingOutcomeService).removeAdjourn(
         adjudicationNumber = 1,
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/HearingControllerTest.kt
@@ -417,7 +417,7 @@ class HearingControllerTest : TestControllerBase() {
     @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER", "SCOPE_write"])
     fun `makes a call to delete an adjourn`() {
       deleteAdjournRequest(1,)
-        .andExpect(MockMvcResultMatchers.status().isCreated)
+        .andExpect(MockMvcResultMatchers.status().isOk)
       verify(hearingOutcomeService).removeAdjourn(
         adjudicationNumber = 1,
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/OutcomeControllerTest.kt
@@ -413,7 +413,7 @@ class OutcomeControllerTest : TestControllerBase() {
     ): ResultActions {
       return mockMvc
         .perform(
-          MockMvcRequestBuilders.delete("/reported-adjudications/$id/outcome/not-proceed")
+          MockMvcRequestBuilders.delete("/reported-adjudications/$id/outcome")
             .header("Content-Type", "application/json")
         )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
@@ -355,4 +355,34 @@ class HearingsIntTest : IntegrationTestBase() {
       .jsonPath("$.hearings[0].dateTimeOfHearing")
       .isEqualTo(IntegrationTestData.DEFAULT_ADJUDICATION.dateTimeOfHearingISOString)
   }
+
+  @Test
+  fun `remove adjourn outcome `() {
+    prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    initDataForHearings().createHearing()
+
+    webTestClient.post()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/outcome/adjourn")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .bodyValue(
+        mapOf(
+          "adjudicator" to "test",
+          "reason" to HearingOutcomeAdjournReason.LEGAL_ADVICE,
+          "details" to "details",
+          "plea" to HearingOutcomePlea.UNFIT,
+        )
+      )
+      .exchange()
+      .expectStatus().isCreated
+
+    webTestClient.delete()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/outcome/adjourn")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.outcomes[0].outcome").doesNotExist()
+      .jsonPath("$.reportedAdjudication.outcomes[0].hearing.outcome").doesNotExist()
+      .jsonPath("$.reportedAdjudication.outcomes[0].hearing").exists()
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
@@ -359,21 +359,7 @@ class HearingsIntTest : IntegrationTestBase() {
   @Test
   fun `remove adjourn outcome `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    initDataForHearings().createHearing()
-
-    webTestClient.post()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/outcome/adjourn")
-      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
-      .bodyValue(
-        mapOf(
-          "adjudicator" to "test",
-          "reason" to HearingOutcomeAdjournReason.LEGAL_ADVICE,
-          "details" to "details",
-          "plea" to HearingOutcomePlea.UNFIT,
-        )
-      )
-      .exchange()
-      .expectStatus().isCreated
+    initDataForHearings().createHearing().createAdjourn()
 
     webTestClient.delete()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/hearing/outcome/adjourn")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
@@ -608,6 +608,26 @@ class IntegrationTestData(
       .blockFirst()!!
   }
 
+  fun createChargeProved(
+    testDataSet: AdjudicationIntTestDataSet,
+  ): ReportedAdjudicationResponse {
+    return webTestClient.post()
+      .uri("/reported-adjudications/${testDataSet.adjudicationNumber}/complete-hearing/charge-proved")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .bodyValue(
+        mapOf(
+          "adjudicator" to "test",
+          "plea" to HearingOutcomePlea.NOT_GUILTY,
+          "amount" to 100.50,
+          "caution" to true,
+        )
+      )
+      .exchange()
+      .returnResult(ReportedAdjudicationResponse::class.java)
+      .responseBody
+      .blockFirst()!!
+  }
+
   fun createReferral(
     testDataSet: AdjudicationIntTestDataSet,
     code: HearingOutcomeCode,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestScenarioBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestScenarioBuilder.kt
@@ -86,6 +86,13 @@ class IntegrationTestScenario(
     return this
   }
 
+  fun createChargeProved(): IntegrationTestScenario {
+    intTestData.createChargeProved(
+      testAdjudicationDataSet,
+    )
+    return this
+  }
+
   fun createAdjourn(): IntegrationTestScenario {
     intTestData.createAdjourn(
       testAdjudicationDataSet,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomePlea
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.NotProceedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.QuashedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 
 class OutcomeIntTest : IntegrationTestBase() {
@@ -215,21 +216,7 @@ class OutcomeIntTest : IntegrationTestBase() {
   @Test
   fun `remove completed hearing outcome `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    initDataForOutcome().createHearing()
-
-    webTestClient.post()
-      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/complete-hearing/charge-proved")
-      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
-      .bodyValue(
-        mapOf(
-          "adjudicator" to "test",
-          "plea" to HearingOutcomePlea.NOT_GUILTY,
-          "amount" to 100.50,
-          "caution" to true,
-        )
-      )
-      .exchange()
-      .expectStatus().isCreated
+    initDataForOutcome().createHearing().createChargeProved()
 
     webTestClient.delete()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/remove-completed-hearing")
@@ -241,5 +228,31 @@ class OutcomeIntTest : IntegrationTestBase() {
       .isEqualTo(ReportedAdjudicationStatus.SCHEDULED.name)
       .jsonPath("$.reportedAdjudication.outcomes[0].outcome").doesNotExist()
       .jsonPath("$.reportedAdjudication.outcomes[0].hearing.outcome").doesNotExist()
+  }
+
+  @Test
+  fun `quash completed hearing outcome `() {
+    prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    initDataForOutcome().createHearing().createChargeProved()
+
+    webTestClient.post()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/outcome/quashed")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .bodyValue(
+        mapOf(
+          "reason" to QuashedReason.APPEAL_UPHELD,
+          "details" to "details",
+        )
+      )
+      .exchange()
+      .expectStatus().isCreated
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.status")
+      .isEqualTo(ReportedAdjudicationStatus.QUASHED.name)
+      .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(2)
+      .jsonPath("$.reportedAdjudication.outcomes[0].outcome.outcome.code").isEqualTo(OutcomeCode.CHARGE_PROVED.name)
+      .jsonPath("$.reportedAdjudication.outcomes[1].outcome.outcome.quashedReason").isEqualTo(QuashedReason.APPEAL_UPHELD.name)
+      .jsonPath("$.reportedAdjudication.outcomes[1].outcome.outcome.details").isEqualTo("details")
+      .jsonPath("$.reportedAdjudication.outcomes[1].outcome.outcome.code").isEqualTo(OutcomeCode.QUASHED.name)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
@@ -412,7 +412,7 @@ class OutcomeServiceTest : ReportedAdjudicationTestBase() {
       )
       verify(reportedAdjudicationRepository).save(argumentCaptor.capture())
 
-      assertThat(argumentCaptor.value.outcomes).isEmpty()
+      if (code == OutcomeCode.NOT_PROCEED) assertThat(argumentCaptor.value.outcomes).isEmpty() else assertThat(argumentCaptor.value.outcomes.size).isEqualTo(1)
       if (code == OutcomeCode.NOT_PROCEED) assertThat(argumentCaptor.value.status).isEqualTo(ReportedAdjudicationStatus.UNSCHEDULED)
       else assertThat(argumentCaptor.value.status).isEqualTo(ReportedAdjudicationStatus.CHARGE_PROVED)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
@@ -231,12 +231,12 @@ class OutcomeServiceTest : ReportedAdjudicationTestBase() {
       assertThat(response).isNotNull
     }
 
-    @CsvSource("REFER_POLICE", "REFER_INAD", "ADJOURN")
+    @CsvSource("REFER_POLICE", "REFER_INAD", "DISMISSED", "SCHEDULE_HEARING", "PROSECUTION", "NOT_PROCEED", "QUASHED")
     @ParameterizedTest
-    fun `create quashed throws exception if previous outcome is not a hearing completed option `(code: HearingOutcomeCode) {
+    fun `create quashed throws exception if previous outcome is not a charge proved `(code: OutcomeCode) {
       whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
         reportedAdjudication.also {
-          it.hearings.first().hearingOutcome = HearingOutcome(code = code, adjudicator = "")
+          it.outcomes.add(Outcome(code = code))
         }
       )
 


### PR DESCRIPTION
changes include

- add create quashed
- add quashed delete to normal delete endpoint (renamed)
- fix remove outcome in outcome history to support quashed + simplify logic
- add remove adjourn to api