### PR TITLE
NN-5028 update punishments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/PunishmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/PunishmentsController.kt
@@ -22,6 +22,8 @@ data class PunishmentsRequest(
 
 @Schema(description = "punishment request")
 data class PunishmentRequest(
+  @Schema(description = "id of punishment")
+  val id: Long? = null,
   @Schema(description = "punishment type")
   val type: PunishmentType,
   @Schema(description = "privilege type - only use if punishment type is PRIVILEGE")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/PunishmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/PunishmentsController.kt
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
@@ -56,6 +57,21 @@ class PunishmentsController(
     @RequestBody punishmentsRequest: PunishmentsRequest,
   ): ReportedAdjudicationResponse {
     val reportedAdjudication = punishmentsService.create(
+      adjudicationNumber = adjudicationNumber,
+      punishments = punishmentsRequest.punishments,
+    )
+
+    return ReportedAdjudicationResponse(reportedAdjudication)
+  }
+
+  @Operation(summary = "updates a set of punishments")
+  @PutMapping(value = ["/{adjudicationNumber}/punishments"])
+  @ResponseStatus(HttpStatus.OK)
+  fun update(
+    @PathVariable(name = "adjudicationNumber") adjudicationNumber: Long,
+    @RequestBody punishmentsRequest: PunishmentsRequest,
+  ): ReportedAdjudicationResponse {
+    val reportedAdjudication = punishmentsService.update(
       adjudicationNumber = adjudicationNumber,
       punishments = punishmentsRequest.punishments,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
@@ -70,6 +70,13 @@ class PunishmentsService(
     return saveToDto(reportedAdjudication)
   }
 
+  fun update(
+    adjudicationNumber: Long,
+    punishments: List<PunishmentRequest>,
+  ): ReportedAdjudicationDto {
+    TODO("implement me")
+  }
+
   companion object {
     fun ReportedAdjudicationStatus.validateCanAddPunishments() {
       if (this != ReportedAdjudicationStatus.CHARGE_PROVED) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.Rep
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.IncidentRoleRuleLookup
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.OffenceCodeLookupService
+import java.time.LocalDateTime
 import javax.persistence.EntityNotFoundException
 
 open class ReportedDtoService(
@@ -239,14 +240,14 @@ open class ReportedDtoService(
     }.sortedBy { it.dateTimeOfIssue }.toList()
 
   private fun List<Punishment>.toPunishments(): List<PunishmentDto> =
-    this.map {
+    this.sortedBy { it.type }.map {
       PunishmentDto(
         id = it.id,
         type = it.type,
         privilegeType = it.privilegeType,
         otherPrivilege = it.otherPrivilege,
         stoppagePercentage = it.stoppagePercentage,
-        schedule = it.schedule.maxBy { latest -> latest.createDateTime!! }.toPunishmentScheduleDto(),
+        schedule = it.schedule.maxBy { latest -> latest.createDateTime ?: LocalDateTime.now() }.toPunishmentScheduleDto(),
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/PunishmentsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/PunishmentsControllerTest.kt
@@ -134,7 +134,7 @@ class PunishmentsControllerTest : TestControllerBase() {
     @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER", "SCOPE_write"])
     fun `makes a call to update a set of punishments`() {
       updatePunishmentsRequest(1, PUNISHMENT_REQUEST)
-        .andExpect(MockMvcResultMatchers.status().isCreated)
+        .andExpect(MockMvcResultMatchers.status().isOk)
 
       verify(punishmentsService).update(
         adjudicationNumber = 1,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/PunishmentsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/PunishmentsControllerTest.kt
@@ -92,6 +92,74 @@ class PunishmentsControllerTest : TestControllerBase() {
     }
   }
 
+  @Nested
+  inner class UpdatePunishments {
+    @BeforeEach
+    fun beforeEach() {
+      whenever(
+        punishmentsService.update(
+          ArgumentMatchers.anyLong(),
+          any(),
+        ),
+      ).thenReturn(REPORTED_ADJUDICATION_DTO)
+    }
+
+    @Test
+    fun `responds with a unauthorised status code`() {
+      updatePunishmentsRequest(
+        1,
+        PUNISHMENT_REQUEST,
+      ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
+    }
+
+    @Test
+    @WithMockUser(username = "ITAG_USER", authorities = ["SCOPE_write"])
+    fun `responds with a forbidden status code for non ALO`() {
+      updatePunishmentsRequest(
+        1,
+        PUNISHMENT_REQUEST,
+      ).andExpect(MockMvcResultMatchers.status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER"])
+    fun `responds with a forbidden status code for ALO without write scope`() {
+      updatePunishmentsRequest(
+        1,
+        PUNISHMENT_REQUEST,
+      ).andExpect(MockMvcResultMatchers.status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(username = "ITAG_USER", authorities = ["ROLE_ADJUDICATIONS_REVIEWER", "SCOPE_write"])
+    fun `makes a call to update a set of punishments`() {
+      updatePunishmentsRequest(1, PUNISHMENT_REQUEST)
+        .andExpect(MockMvcResultMatchers.status().isCreated)
+
+      verify(punishmentsService).update(
+        adjudicationNumber = 1,
+        listOf(PunishmentRequest(type = PUNISHMENT_REQUEST.type, days = PUNISHMENT_REQUEST.days)),
+      )
+    }
+
+    private fun updatePunishmentsRequest(
+      id: Long,
+      punishmentRequest: PunishmentRequest,
+    ): ResultActions {
+      val body = objectMapper.writeValueAsString(
+        PunishmentsRequest(
+          punishments = listOf(punishmentRequest),
+        ),
+      )
+      return mockMvc
+        .perform(
+          MockMvcRequestBuilders.put("/reported-adjudications/$id/punishments")
+            .header("Content-Type", "application/json")
+            .content(body),
+        )
+    }
+  }
+
   companion object {
     val PUNISHMENT_REQUEST = PunishmentRequest(type = PunishmentType.REMOVAL_ACTIVITY, days = 10)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/PunishmentsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/PunishmentsIntTest.kt
@@ -11,7 +11,7 @@ class PunishmentsIntTest : IntegrationTestBase() {
 
   @BeforeEach
   fun setUp() {
-    setAuditTime(IntegrationTestData.DEFAULT_REPORTED_DATE_TIME)
+    setAuditTime()
   }
 
   @Test
@@ -75,7 +75,7 @@ class PunishmentsIntTest : IntegrationTestBase() {
       .responseBody
       .blockFirst()!!
 
-    val punishmentToAmend = reportedAdjudicationResponse.reportedAdjudication.punishments.first().id!!
+    val punishmentToAmend = reportedAdjudicationResponse.reportedAdjudication.punishments.first { it.type == PunishmentType.CONFINEMENT }.id
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/punishments")
@@ -109,7 +109,7 @@ class PunishmentsIntTest : IntegrationTestBase() {
       .jsonPath("$.reportedAdjudication.punishments[0].schedule.startDate").isEqualTo("2023-03-27")
       .jsonPath("$.reportedAdjudication.punishments[0].schedule.endDate").isEqualTo("2023-03-27")
       .jsonPath("$.reportedAdjudication.punishments[1].type").isEqualTo(PunishmentType.EXCLUSION_WORK.name)
-      .jsonPath("$.reportedAdjudication.punishments[1].schedule.days").isEqualTo(10)
+      .jsonPath("$.reportedAdjudication.punishments[1].schedule.days").isEqualTo(8)
       .jsonPath("$.reportedAdjudication.punishments[1].schedule.suspendedUntil").isEqualTo("2023-03-27")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/PunishmentsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/PunishmentsIntTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.reported.PunishmentRequest
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.reported.ReportedAdjudicationResponse
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentType
 import java.time.LocalDate
 
@@ -41,5 +42,74 @@ class PunishmentsIntTest : IntegrationTestBase() {
       .jsonPath("$.reportedAdjudication.punishments[0].type").isEqualTo(PunishmentType.CONFINEMENT.name)
       .jsonPath("$.reportedAdjudication.punishments[0].schedule.days").isEqualTo(10)
       .jsonPath("$.reportedAdjudication.punishments[0].schedule.suspendedUntil").isEqualTo("2023-03-27")
+  }
+
+  @Test
+  fun `update punishments - amends one record, removes a record, and creates a record`() {
+    prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    initDataForOutcome().createHearing().createChargeProved()
+
+    val suspendedUntil = LocalDate.of(2023, 3, 27)
+    val reportedAdjudicationResponse = webTestClient.post()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/punishments")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .bodyValue(
+        mapOf(
+          "punishments" to
+            listOf(
+              PunishmentRequest(
+                type = PunishmentType.CONFINEMENT,
+                days = 10,
+                suspendedUntil = suspendedUntil,
+              ),
+              PunishmentRequest(
+                type = PunishmentType.REMOVAL_ACTIVITY,
+                days = 10,
+                suspendedUntil = suspendedUntil,
+              ),
+            ),
+        ),
+      )
+      .exchange()
+      .returnResult(ReportedAdjudicationResponse::class.java)
+      .responseBody
+      .blockFirst()!!
+
+    val punishmentToAmend = reportedAdjudicationResponse.reportedAdjudication.punishments.first().id!!
+
+    webTestClient.put()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/punishments")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .bodyValue(
+        mapOf(
+          "punishments" to
+            listOf(
+              PunishmentRequest(
+                id = punishmentToAmend,
+                type = PunishmentType.CONFINEMENT,
+                days = 15,
+                startDate = suspendedUntil,
+                endDate = suspendedUntil,
+              ),
+              PunishmentRequest(
+                type = PunishmentType.EXCLUSION_WORK,
+                days = 8,
+                suspendedUntil = suspendedUntil,
+              ),
+            ),
+        ),
+      )
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.punishments.size()").isEqualTo(2)
+      .jsonPath("$.reportedAdjudication.punishments[0].id").isEqualTo(punishmentToAmend)
+      .jsonPath("$.reportedAdjudication.punishments[0].type").isEqualTo(PunishmentType.CONFINEMENT.name)
+      .jsonPath("$.reportedAdjudication.punishments[0].schedule.days").isEqualTo(15)
+      .jsonPath("$.reportedAdjudication.punishments[0].schedule.startDate").isEqualTo("2023-03-27")
+      .jsonPath("$.reportedAdjudication.punishments[0].schedule.endDate").isEqualTo("2023-03-27")
+      .jsonPath("$.reportedAdjudication.punishments[1].type").isEqualTo(PunishmentType.EXCLUSION_WORK.name)
+      .jsonPath("$.reportedAdjudication.punishments[1].schedule.days").isEqualTo(10)
+      .jsonPath("$.reportedAdjudication.punishments[1].schedule.suspendedUntil").isEqualTo("2023-03-27")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsServiceTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported
 
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -16,6 +18,8 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Hearing
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Outcome
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PrivilegeType
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Punishment
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentSchedule
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentType
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudication
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
@@ -33,8 +37,19 @@ class PunishmentsServiceTest : ReportedAdjudicationTestBase() {
   )
 
   override fun `throws an entity not found if the reported adjudication for the supplied id does not exists`() {
-    Assertions.assertThatThrownBy {
-      punishmentsService.create(adjudicationNumber = 1, listOf(PunishmentRequest(type = PunishmentType.REMOVAL_ACTIVITY, days = 1)))
+    assertThatThrownBy {
+      punishmentsService.create(
+        adjudicationNumber = 1,
+        listOf(PunishmentRequest(type = PunishmentType.REMOVAL_ACTIVITY, days = 1)),
+      )
+    }.isInstanceOf(EntityNotFoundException::class.java)
+      .hasMessageContaining("ReportedAdjudication not found for 1")
+
+    assertThatThrownBy {
+      punishmentsService.update(
+        adjudicationNumber = 1,
+        listOf(PunishmentRequest(type = PunishmentType.REMOVAL_ACTIVITY, days = 1)),
+      )
     }.isInstanceOf(EntityNotFoundException::class.java)
       .hasMessageContaining("ReportedAdjudication not found for 1")
   }
@@ -67,8 +82,11 @@ class PunishmentsServiceTest : ReportedAdjudicationTestBase() {
       whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
         reportedAdjudication.also { it.status = status },
       )
-      Assertions.assertThatThrownBy {
-        punishmentsService.create(adjudicationNumber = 1, listOf(PunishmentRequest(type = PunishmentType.REMOVAL_ACTIVITY, days = 1)))
+      assertThatThrownBy {
+        punishmentsService.create(
+          adjudicationNumber = 1,
+          listOf(PunishmentRequest(type = PunishmentType.REMOVAL_ACTIVITY, days = 1)),
+        )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("status is not CHARGE_PROVED")
     }
@@ -76,50 +94,92 @@ class PunishmentsServiceTest : ReportedAdjudicationTestBase() {
     @Test
     fun `validation error - privilege missing sub type `() {
       Assertions.assertThatThrownBy {
-        punishmentsService.create(adjudicationNumber = 1, listOf(PunishmentRequest(type = PunishmentType.PRIVILEGE, days = 1)))
+        punishmentsService.create(
+          adjudicationNumber = 1,
+          listOf(PunishmentRequest(type = PunishmentType.PRIVILEGE, days = 1)),
+        )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("subtype missing for type PRIVILEGE")
     }
 
     @Test
     fun `validation error - other privilege missing description `() {
-      Assertions.assertThatThrownBy {
-        punishmentsService.create(adjudicationNumber = 1, listOf(PunishmentRequest(type = PunishmentType.PRIVILEGE, privilegeType = PrivilegeType.OTHER, days = 1)))
+      assertThatThrownBy {
+        punishmentsService.create(
+          adjudicationNumber = 1,
+          listOf(PunishmentRequest(type = PunishmentType.PRIVILEGE, privilegeType = PrivilegeType.OTHER, days = 1)),
+        )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("description missing for type PRIVILEGE - sub type OTHER")
     }
 
     @Test
     fun `validation error - earnings missing stoppage percentage `() {
-      Assertions.assertThatThrownBy {
-        punishmentsService.create(adjudicationNumber = 1, listOf(PunishmentRequest(type = PunishmentType.EARNINGS, days = 1)))
+      assertThatThrownBy {
+        punishmentsService.create(
+          adjudicationNumber = 1,
+          listOf(PunishmentRequest(type = PunishmentType.EARNINGS, days = 1)),
+        )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("stoppage percentage missing for type EARNINGS")
     }
 
-    @CsvSource(" PRIVILEGE", "EARNINGS", "CONFINEMENT", "REMOVAL_ACTIVITY", "EXCLUSION_WORK", "EXTRA_WORK", "REMOVAL_WING")
+    @CsvSource(
+      " PRIVILEGE",
+      "EARNINGS",
+      "CONFINEMENT",
+      "REMOVAL_ACTIVITY",
+      "EXCLUSION_WORK",
+      "EXTRA_WORK",
+      "REMOVAL_WING",
+    )
     @ParameterizedTest
     fun `validation error - not suspended missing start date `(type: PunishmentType) {
-      Assertions.assertThatThrownBy {
-        punishmentsService.create(adjudicationNumber = 1, listOf(PunishmentRequest(type = PunishmentType.REMOVAL_ACTIVITY, days = 1, endDate = LocalDate.now())))
+      assertThatThrownBy {
+        punishmentsService.create(
+          adjudicationNumber = 1,
+          listOf(getRequest(type = type, endDate = LocalDate.now())),
+        )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("missing start date for schedule")
     }
 
-    @CsvSource(" PRIVILEGE", "EARNINGS", "CONFINEMENT", "REMOVAL_ACTIVITY", "EXCLUSION_WORK", "EXTRA_WORK", "REMOVAL_WING")
+    @CsvSource(
+      " PRIVILEGE",
+      "EARNINGS",
+      "CONFINEMENT",
+      "REMOVAL_ACTIVITY",
+      "EXCLUSION_WORK",
+      "EXTRA_WORK",
+      "REMOVAL_WING",
+    )
     @ParameterizedTest
-    fun `validation error - not suspended missing end date `() {
-      Assertions.assertThatThrownBy {
-        punishmentsService.create(adjudicationNumber = 1, listOf(PunishmentRequest(type = PunishmentType.REMOVAL_ACTIVITY, days = 1, startDate = LocalDate.now())))
+    fun `validation error - not suspended missing end date `(type: PunishmentType) {
+      assertThatThrownBy {
+        punishmentsService.create(
+          adjudicationNumber = 1,
+          listOf(getRequest(type = type, startDate = LocalDate.now())),
+        )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("missing end date for schedule")
     }
 
-    @CsvSource(" PRIVILEGE", "EARNINGS", "CONFINEMENT", "REMOVAL_ACTIVITY", "EXCLUSION_WORK", "EXTRA_WORK", "REMOVAL_WING")
+    @CsvSource(
+      " PRIVILEGE",
+      "EARNINGS",
+      "CONFINEMENT",
+      "REMOVAL_ACTIVITY",
+      "EXCLUSION_WORK",
+      "EXTRA_WORK",
+      "REMOVAL_WING",
+    )
     @ParameterizedTest
-    fun `validation error - suspended missing all schedule dates `() {
-      Assertions.assertThatThrownBy {
-        punishmentsService.create(adjudicationNumber = 1, listOf(PunishmentRequest(type = PunishmentType.REMOVAL_ACTIVITY, days = 1)))
+    fun `validation error - suspended missing all schedule dates `(type: PunishmentType) {
+      assertThatThrownBy {
+        punishmentsService.create(
+          adjudicationNumber = 1,
+          listOf(getRequest(type = type)),
+        )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("missing all schedule data")
     }
@@ -151,17 +211,358 @@ class PunishmentsServiceTest : ReportedAdjudicationTestBase() {
 
       verify(reportedAdjudicationRepository).save(argumentCaptor.capture())
 
-      Assertions.assertThat(argumentCaptor.value.punishments.size).isEqualTo(3)
-      Assertions.assertThat(argumentCaptor.value.punishments.first()).isNotNull
-      Assertions.assertThat(argumentCaptor.value.punishments.first().type).isEqualTo(PunishmentType.PRIVILEGE)
-      Assertions.assertThat(argumentCaptor.value.punishments.first().privilegeType).isEqualTo(PrivilegeType.OTHER)
-      Assertions.assertThat(argumentCaptor.value.punishments.first().otherPrivilege).isEqualTo("other")
-      Assertions.assertThat(argumentCaptor.value.punishments.first().schedule.first()).isNotNull
-      Assertions.assertThat(argumentCaptor.value.punishments.first().schedule.first().startDate).isEqualTo(LocalDate.now())
-      Assertions.assertThat(argumentCaptor.value.punishments.first().schedule.first().endDate).isEqualTo(LocalDate.now().plusDays(1))
-      Assertions.assertThat(argumentCaptor.value.punishments.first().schedule.first().days).isEqualTo(1)
+      assertThat(argumentCaptor.value.punishments.size).isEqualTo(3)
+      assertThat(argumentCaptor.value.punishments.first()).isNotNull
+      assertThat(argumentCaptor.value.punishments.first().type).isEqualTo(PunishmentType.PRIVILEGE)
+      assertThat(argumentCaptor.value.punishments.first().privilegeType).isEqualTo(PrivilegeType.OTHER)
+      assertThat(argumentCaptor.value.punishments.first().otherPrivilege).isEqualTo("other")
+      assertThat(argumentCaptor.value.punishments.first().schedule.first()).isNotNull
+      assertThat(argumentCaptor.value.punishments.first().schedule.first().startDate)
+        .isEqualTo(LocalDate.now())
+      assertThat(argumentCaptor.value.punishments.first().schedule.first().endDate)
+        .isEqualTo(LocalDate.now().plusDays(1))
+      assertThat(argumentCaptor.value.punishments.first().schedule.first().days).isEqualTo(1)
 
-      Assertions.assertThat(response).isNotNull
+      assertThat(response).isNotNull
     }
+  }
+
+  @Nested
+  inner class UpdatePunishments {
+
+    private val reportedAdjudication = entityBuilder.reportedAdjudication(dateTime = DATE_TIME_OF_INCIDENT)
+
+    @BeforeEach
+    fun `init`() {
+      whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
+        reportedAdjudication.also {
+          it.status = ReportedAdjudicationStatus.CHARGE_PROVED
+          it.hearings.first().hearingOutcome = HearingOutcome(code = HearingOutcomeCode.COMPLETE, adjudicator = "")
+          it.outcomes.add(Outcome(code = OutcomeCode.CHARGE_PROVED))
+          it.createdByUserId = "test"
+          it.createDateTime = LocalDateTime.now()
+        },
+      )
+      whenever(reportedAdjudicationRepository.save(any())).thenReturn(reportedAdjudication)
+    }
+
+    @CsvSource(
+      "ADJOURNED", "REFER_POLICE", "REFER_INAD", "SCHEDULED", "UNSCHEDULED", "AWAITING_REVIEW", "PROSECUTION",
+      "NOT_PROCEED", "DISMISSED", "REJECTED", "RETURNED",
+    )
+    @ParameterizedTest
+    fun `validation error - wrong status code - must be CHARGE_PROVED `(status: ReportedAdjudicationStatus) {
+      whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
+        reportedAdjudication.also { it.status = status },
+      )
+      assertThatThrownBy {
+        punishmentsService.update(
+          adjudicationNumber = 1,
+          listOf(PunishmentRequest(type = PunishmentType.REMOVAL_ACTIVITY, days = 1)),
+        )
+      }.isInstanceOf(ValidationException::class.java)
+        .hasMessageContaining("status is not CHARGE_PROVED")
+    }
+
+    @Test
+    fun `validation error - privilege missing sub type `() {
+      whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
+        reportedAdjudication.also {
+          it.punishments.add(
+            Punishment(
+              id = 1,
+              type = PunishmentType.PRIVILEGE,
+              privilegeType = PrivilegeType.ASSOCIATION,
+              schedule = mutableListOf(
+                PunishmentSchedule(id = 1, days = 1, suspendedUntil = LocalDate.now()),
+              ),
+            ),
+          )
+        },
+      )
+
+      assertThatThrownBy {
+        punishmentsService.update(
+          adjudicationNumber = 1,
+          listOf(PunishmentRequest(id = 1, type = PunishmentType.PRIVILEGE, days = 1)),
+        )
+      }.isInstanceOf(ValidationException::class.java)
+        .hasMessageContaining("subtype missing for type PRIVILEGE")
+    }
+
+    @Test
+    fun `validation error - other privilege missing description `() {
+      whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
+        reportedAdjudication.also {
+          it.punishments.add(
+            Punishment(
+              id = 1,
+              type = PunishmentType.PRIVILEGE,
+              privilegeType = PrivilegeType.OTHER,
+              otherPrivilege = "",
+              schedule = mutableListOf(
+                PunishmentSchedule(id = 1, days = 1, suspendedUntil = LocalDate.now()),
+              ),
+            ),
+          )
+        },
+      )
+
+      assertThatThrownBy {
+        punishmentsService.update(
+          adjudicationNumber = 1,
+          listOf(
+            PunishmentRequest(
+              id = 1,
+              type = PunishmentType.PRIVILEGE,
+              privilegeType = PrivilegeType.OTHER,
+              days = 1,
+            ),
+          ),
+        )
+      }.isInstanceOf(ValidationException::class.java)
+        .hasMessageContaining("description missing for type PRIVILEGE - sub type OTHER")
+    }
+
+    @Test
+    fun `validation error - earnings missing stoppage percentage `() {
+      whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
+        reportedAdjudication.also {
+          it.punishments.add(
+            Punishment(
+              id = 1,
+              type = PunishmentType.EARNINGS,
+              stoppagePercentage = 10,
+              schedule = mutableListOf(
+                PunishmentSchedule(id = 1, days = 1, suspendedUntil = LocalDate.now()),
+              ),
+            ),
+          )
+        },
+      )
+      assertThatThrownBy {
+        punishmentsService.update(
+          adjudicationNumber = 1,
+          listOf(PunishmentRequest(id = 1, type = PunishmentType.EARNINGS, days = 1)),
+        )
+      }.isInstanceOf(ValidationException::class.java)
+        .hasMessageContaining("stoppage percentage missing for type EARNINGS")
+    }
+
+    @CsvSource(
+      " PRIVILEGE",
+      "EARNINGS",
+      "CONFINEMENT",
+      "REMOVAL_ACTIVITY",
+      "EXCLUSION_WORK",
+      "EXTRA_WORK",
+      "REMOVAL_WING",
+    )
+    @ParameterizedTest
+    fun `validation error - not suspended missing start date `(type: PunishmentType) {
+      whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
+        reportedAdjudication.also {
+          it.punishments.add(
+            Punishment(
+              id = 1,
+              type = type,
+              schedule = mutableListOf(
+                PunishmentSchedule(id = 1, days = 1, suspendedUntil = LocalDate.now()),
+              ),
+            ),
+          )
+        },
+      )
+      assertThatThrownBy {
+        punishmentsService.update(
+          adjudicationNumber = 1,
+          listOf(getRequest(id = 1, type = type, endDate = LocalDate.now())),
+        )
+      }.isInstanceOf(ValidationException::class.java)
+        .hasMessageContaining("missing start date for schedule")
+    }
+
+    @CsvSource(
+      " PRIVILEGE",
+      "EARNINGS",
+      "CONFINEMENT",
+      "REMOVAL_ACTIVITY",
+      "EXCLUSION_WORK",
+      "EXTRA_WORK",
+      "REMOVAL_WING",
+    )
+    @ParameterizedTest
+    fun `validation error - not suspended missing end date `(type: PunishmentType) {
+      whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
+        reportedAdjudication.also {
+          it.punishments.add(
+            Punishment(
+              id = 1,
+              type = type,
+              schedule = mutableListOf(
+                PunishmentSchedule(id = 1, days = 1, suspendedUntil = LocalDate.now()),
+              ),
+            ),
+          )
+        },
+      )
+      assertThatThrownBy {
+        punishmentsService.update(
+          adjudicationNumber = 1,
+          listOf(
+            getRequest(id = 1, type = type, startDate = LocalDate.now()),
+          ),
+        )
+      }.isInstanceOf(ValidationException::class.java)
+        .hasMessageContaining("missing end date for schedule")
+    }
+
+    @CsvSource(
+      " PRIVILEGE",
+      "EARNINGS",
+      "CONFINEMENT",
+      "REMOVAL_ACTIVITY",
+      "EXCLUSION_WORK",
+      "EXTRA_WORK",
+      "REMOVAL_WING",
+    )
+    @ParameterizedTest
+    fun `validation error - suspended missing all schedule dates `(type: PunishmentType) {
+      whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
+        reportedAdjudication.also {
+          it.punishments.add(
+            Punishment(
+              id = 1,
+              type = type,
+              schedule = mutableListOf(
+                PunishmentSchedule(id = 1, days = 1, suspendedUntil = LocalDate.now()),
+              ),
+            ),
+          )
+        },
+      )
+
+      assertThatThrownBy {
+        punishmentsService.update(
+          adjudicationNumber = 1,
+          listOf(getRequest(id = 1, type = type)),
+        )
+      }.isInstanceOf(ValidationException::class.java)
+        .hasMessageContaining("missing all schedule data")
+    }
+
+    @Test
+    fun `throws exception if id for punishment is not located `() {
+      whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
+        reportedAdjudication.also {
+          it.punishments.add(
+            Punishment(
+              id = 1,
+              type = PunishmentType.CONFINEMENT,
+              schedule = mutableListOf(
+                PunishmentSchedule(id = 1, days = 1, suspendedUntil = LocalDate.now()),
+              ),
+            ),
+          )
+        },
+      )
+
+      assertThatThrownBy {
+        punishmentsService.update(
+          adjudicationNumber = 1,
+          listOf(PunishmentRequest(id = 2, type = PunishmentType.REMOVAL_ACTIVITY, days = 1)),
+        )
+      }.isInstanceOf(EntityNotFoundException::class.java)
+        .hasMessageContaining("Punishment 2 is not associated with ReportedAdjudication 1")
+    }
+
+    @Test
+    fun `update punishments `() {
+      whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
+        reportedAdjudication.also {
+          it.punishments.addAll(
+            mutableListOf(
+              Punishment(
+                id = 1,
+                type = PunishmentType.CONFINEMENT,
+                schedule = mutableListOf(
+                  PunishmentSchedule(id = 1, days = 1, suspendedUntil = LocalDate.now()),
+                ),
+              ),
+              Punishment(
+                id = 2,
+                type = PunishmentType.EXCLUSION_WORK,
+                schedule = mutableListOf(
+                  PunishmentSchedule(id = 1, days = 1, suspendedUntil = LocalDate.now()),
+                ),
+              ),
+              Punishment(
+                id = 3,
+                type = PunishmentType.ADDITIONAL_DAYS,
+                schedule = mutableListOf(
+                  PunishmentSchedule(id = 1, days = 1),
+                ),
+              ),
+            ),
+          )
+        },
+      )
+
+      val argumentCaptor = ArgumentCaptor.forClass(ReportedAdjudication::class.java)
+
+      verify(reportedAdjudicationRepository).save(argumentCaptor.capture())
+      val response = punishmentsService.update(
+        adjudicationNumber = 1,
+        listOf(
+          PunishmentRequest(
+            id = 1,
+            type = PunishmentType.PRIVILEGE,
+            privilegeType = PrivilegeType.OTHER,
+            otherPrivilege = "other",
+            days = 1,
+            startDate = LocalDate.now(),
+            endDate = LocalDate.now().plusDays(1),
+          ),
+          PunishmentRequest(
+            type = PunishmentType.PROSPECTIVE_DAYS,
+            days = 1,
+          ),
+          PunishmentRequest(
+            id = 3,
+            type = PunishmentType.ADDITIONAL_DAYS,
+            days = 2,
+          ),
+        ),
+      )
+
+      assertThat(response).isNotNull
+      assertThat(argumentCaptor.value.punishments.size).isEqualTo(3)
+
+      val privilege = argumentCaptor.value.punishments.first { it.type == PunishmentType.PRIVILEGE }
+      val additionalDays = argumentCaptor.value.punishments.first { it.type == PunishmentType.ADDITIONAL_DAYS }
+      val prospectiveDays = argumentCaptor.value.punishments.first { it.type == PunishmentType.PROSPECTIVE_DAYS }
+      assertThat(argumentCaptor.value.punishments.firstOrNull { it.type == PunishmentType.EXCLUSION_WORK })
+
+      assertThat(privilege.id).isNotEqualTo(1)
+      assertThat(additionalDays.id).isEqualTo(3)
+      assertThat(additionalDays.schedule.size).isEqualTo(2)
+      assertThat(prospectiveDays.schedule.size).isEqualTo(1)
+      assertThat(prospectiveDays.schedule.first().days).isEqualTo(2)
+      assertThat(privilege.schedule.first().startDate).isEqualTo(LocalDate.now())
+      assertThat(privilege.schedule.first().endDate).isEqualTo(LocalDate.now().plusDays(1))
+      assertThat(privilege.otherPrivilege).isEqualTo("other")
+      assertThat(privilege.privilegeType).isEqualTo(PrivilegeType.OTHER)
+    }
+  }
+
+  companion object {
+
+    fun getRequest(id: Long? = null, type: PunishmentType, startDate: LocalDate? = null, endDate: LocalDate? = null): PunishmentRequest =
+      when (type) {
+        PunishmentType.PRIVILEGE -> PunishmentRequest(id = id, type = type, privilegeType = PrivilegeType.ASSOCIATION, days = 1, startDate = startDate, endDate = endDate)
+        PunishmentType.EARNINGS -> PunishmentRequest(id = id, type = type, stoppagePercentage = 10, days = 1, startDate = startDate, endDate = endDate)
+
+        else -> PunishmentRequest(id = id, type = type, days = 1, startDate = startDate, endDate = endDate)
+      }
   }
 }


### PR DESCRIPTION
updates punishments table

-  if id is present, and type is same, updates including schedule
- if id present and type has changed, will remove and add
- removes any records which are no longer in the payload
- adds any new records when no id present in payload