### PR TITLE
Include BUILD_NUMBER in the run stage of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN ./gradlew clean assemble -Dorg.gradle.daemon=false
 FROM eclipse-temurin:19_36-jre-alpine
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
+ARG BUILD_NUMBER
+ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
+
 RUN apk --no-cache upgrade
 
 ENV TZ=Europe/London


### PR DESCRIPTION
I noticed in AppInsights the application_Version was `${BUILD_NUMBER}`, so checked other services and the Kotlin Template (https://github.com/ministryofjustice/hmpps-template-kotlin/blob/fe470fa32d8c162981a873976928dfedb42d004d/Dockerfile#L13-L14)