### PR TITLE
Fix for gradle_owasp_dependency_check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.1
+  hmpps: ministryofjustice/hmpps@7
 
 parameters:
   alerts-slack-channel:
@@ -114,6 +114,8 @@ workflows:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars
+          cache_key: "v2_0"
+          jdk_tag: "19.0"
       - hmpps/trivy_latest_scan:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:


### PR DESCRIPTION
Same as https://github.com/ministryofjustice/hmpps-incentives-api/pull/418

See https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-manage-adjudications-api/2073/workflows/3610f29a-8a75-4264-8455-c949493ae138/jobs/5162 for failures