### PR TITLE
NN-5054 NN-5057 sanction integration and removal of punishments

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.1.3"
+  id("jacoco")
   kotlin("plugin.spring") version "1.8.20"
   kotlin("plugin.jpa") version "1.8.20"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/Outcome.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/Outcome.kt
@@ -23,6 +23,8 @@ data class Outcome(
   @Enumerated(EnumType.STRING)
   var quashedReason: QuashedReason? = null,
   var oicHearingId: Long? = null,
+  var damagesOwedSanctionSeq: Long? = null,
+  var cautionSanctionSeq: Long? = null,
 ) : BaseEntity()
 
 enum class OutcomeCode(val status: ReportedAdjudicationStatus, val finding: Finding? = null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/Outcome.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/Outcome.kt
@@ -18,13 +18,9 @@ data class Outcome(
   var reason: NotProceedReason? = null,
   @Enumerated(EnumType.STRING)
   var code: OutcomeCode,
-  var amount: Double? = null,
-  var caution: Boolean? = null,
   @Enumerated(EnumType.STRING)
   var quashedReason: QuashedReason? = null,
   var oicHearingId: Long? = null,
-  var damagesOwedSanctionSeq: Long? = null,
-  var cautionSanctionSeq: Long? = null,
 ) : BaseEntity()
 
 enum class OutcomeCode(val status: ReportedAdjudicationStatus, val finding: Finding? = null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/Punishment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/Punishment.kt
@@ -25,13 +25,15 @@ data class Punishment(
   var activatedBy: Long? = null,
   var activatedFrom: Long? = null,
   var suspendedUntil: LocalDate? = null,
+  var amount: Double? = null,
+  var sanctionSeq: Long? = null,
   @OneToMany(cascade = [CascadeType.ALL], fetch = FetchType.EAGER)
   @JoinColumn(name = "punishment_fk_id")
   var schedule: MutableList<PunishmentSchedule>,
 ) : BaseEntity()
 
 enum class PunishmentType {
-  PRIVILEGE, EARNINGS, CONFINEMENT, REMOVAL_ACTIVITY, EXCLUSION_WORK, EXTRA_WORK, REMOVAL_WING, ADDITIONAL_DAYS, PROSPECTIVE_DAYS
+  PRIVILEGE, EARNINGS, CONFINEMENT, REMOVAL_ACTIVITY, EXCLUSION_WORK, EXTRA_WORK, REMOVAL_WING, ADDITIONAL_DAYS, PROSPECTIVE_DAYS, CAUTION, DAMAGES_OWED,
 }
 enum class PrivilegeType {
   CANTEEN, FACILITIES, MONEY, TV, ASSOCIATION, OTHER

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisSanctionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisSanctionDto.kt
@@ -70,3 +70,5 @@ data class OffenderOicSanctionRequest(
     }
   }
 }
+
+data class OffenderOicSanctionResponse(val sanctionSeq: Long)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisSanctionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisSanctionDto.kt
@@ -25,9 +25,32 @@ data class OffenderOicSanctionRequest(
 ) {
   companion object {
 
-    private fun oicSanctionCodeMapper(punishmentType: PunishmentType, privilegeType: PrivilegeType?): OicSanctionCode = TODO()
+    private fun oicSanctionCodeMapper(punishmentType: PunishmentType, privilegeType: PrivilegeType?): OicSanctionCode =
+      when (punishmentType) {
+        PunishmentType.PRIVILEGE -> when (privilegeType) {
+          PrivilegeType.CANTEEN -> OicSanctionCode.CANTEEN
+          PrivilegeType.FACILITIES -> TODO()
+          PrivilegeType.MONEY -> TODO()
+          PrivilegeType.TV -> TODO()
+          PrivilegeType.ASSOCIATION -> OicSanctionCode.ASSO
+          PrivilegeType.OTHER -> OicSanctionCode.OTHER
+          null -> throw RuntimeException("fatal - no privilege type specified")
+        }
+        PunishmentType.EARNINGS -> OicSanctionCode.STOP_PCT
+        PunishmentType.CONFINEMENT -> OicSanctionCode.CC
+        PunishmentType.REMOVAL_ACTIVITY -> OicSanctionCode.REMACT
+        PunishmentType.EXCLUSION_WORK -> TODO()
+        PunishmentType.EXTRA_WORK -> TODO()
+        PunishmentType.REMOVAL_WING -> OicSanctionCode.REMACT
+        PunishmentType.ADDITIONAL_DAYS -> TODO()
+        PunishmentType.PROSPECTIVE_DAYS -> TODO()
+      }
 
-    private fun PunishmentSchedule.statusMapper(): Status = TODO()
+    private fun PunishmentSchedule.statusMapper(): Status =
+      when (this.startDate) {
+        null -> TODO()
+        else -> Status.AS_AWARDED
+      }
 
     fun Punishment.mapPunishmentToSanction(damagesOwed: Double?): OffenderOicSanctionRequest {
       val latestSchedule = this.schedule.maxBy { it.createDateTime!! }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisSanctionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisSanctionDto.kt
@@ -1,67 +1,47 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways
 
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PrivilegeType
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Punishment
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentSchedule
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentType
 import java.time.LocalDate
 
 enum class OicSanctionCode {
-  ADA,
-  ASSO,
-  ASS_DINING,
-  ASS_NEWS,
-  ASS_SNACKS,
-  BEDDG_OWN,
-  BEST_JOBS,
-  BONUS_PNTS,
-  CANTEEN,
-  CAUTION,
-  CC,
-  CELL_ELEC,
-  CELL_FURN,
-  COOK_FAC,
-  EXTRA_WORK,
-  EXTW,
-  FOOD_CHOIC,
-  FORFEIT,
-  GAMES_ELEC,
-  INCOM_TEL,
-  MAIL_ORDER,
-  MEAL_TIMES,
-  OIC,
-  OTHER,
-  PADA,
-  PIC,
-  POSSESSION,
-  PUBL,
-  REMACT,
-  REMWIN,
-  STOP_EARN,
-  STOP_PCT,
-  TOBA,
-  USE_FRIDGE,
-  USE_GYM,
-  USE_LAUNDRY,
-  USE_LIBRARY,
-  VISIT_HRS,
-  ;
+  ADA, ASSO, ASS_DINING, ASS_NEWS, ASS_SNACKS, BEDDG_OWN, BEST_JOBS, BONUS_PNTS, CANTEEN, CAUTION, CC, CELL_ELEC, CELL_FURN, COOK_FAC, EXTRA_WORK,
+  EXTW, FOOD_CHOIC, FORFEIT, GAMES_ELEC, INCOM_TEL, MAIL_ORDER, MEAL_TIMES, OIC, OTHER, PADA, PIC, POSSESSION, PUBL, REMACT, REMWIN, STOP_EARN,
+  STOP_PCT, TOBA, USE_FRIDGE, USE_GYM, USE_LAUNDRY, USE_LIBRARY, VISIT_HRS,
 }
 
 enum class Status {
-  AS_AWARDED,
-  AWARD_RED,
-  IMMEDIATE,
-  PROSPECTIVE,
-  QUASHED,
-  REDAPP,
-  SUSPENDED,
-  SUSPEN_EXT,
-  SUSPEN_RED,
-  SUSP_PROSP,
-  ;
+  AS_AWARDED, AWARD_RED, IMMEDIATE, PROSPECTIVE, QUASHED, REDAPP, SUSPENDED, SUSPEN_EXT, SUSPEN_RED, SUSP_PROSP,
 }
 
 data class OffenderOicSanctionRequest(
   val oicSanctionCode: OicSanctionCode,
   val status: Status,
   val effectiveDate: LocalDate,
-  val compensationAmount: Double,
+  val compensationAmount: Double? = null,
   val sanctionDays: Long,
-)
+) {
+  companion object {
+
+    private fun oicSanctionCodeMapper(punishmentType: PunishmentType, privilegeType: PrivilegeType?): OicSanctionCode = TODO()
+
+    private fun PunishmentSchedule.statusMapper(): Status = TODO()
+
+    fun Punishment.mapPunishmentToSanction(damagesOwed: Double?): OffenderOicSanctionRequest {
+      val latestSchedule = this.schedule.maxBy { it.createDateTime!! }
+
+      return OffenderOicSanctionRequest(
+        oicSanctionCode = oicSanctionCodeMapper(
+          punishmentType = this.type,
+          privilegeType = this.privilegeType,
+        ),
+        status = latestSchedule.statusMapper(),
+        effectiveDate = latestSchedule.suspendedUntil ?: latestSchedule.startDate!!,
+        sanctionDays = latestSchedule.days.toLong(),
+        compensationAmount = damagesOwed,
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisSanctionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisSanctionDto.kt
@@ -1,0 +1,67 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways
+
+import java.time.LocalDate
+
+enum class OicSanctionCode {
+  ADA,
+  ASSO,
+  ASS_DINING,
+  ASS_NEWS,
+  ASS_SNACKS,
+  BEDDG_OWN,
+  BEST_JOBS,
+  BONUS_PNTS,
+  CANTEEN,
+  CAUTION,
+  CC,
+  CELL_ELEC,
+  CELL_FURN,
+  COOK_FAC,
+  EXTRA_WORK,
+  EXTW,
+  FOOD_CHOIC,
+  FORFEIT,
+  GAMES_ELEC,
+  INCOM_TEL,
+  MAIL_ORDER,
+  MEAL_TIMES,
+  OIC,
+  OTHER,
+  PADA,
+  PIC,
+  POSSESSION,
+  PUBL,
+  REMACT,
+  REMWIN,
+  STOP_EARN,
+  STOP_PCT,
+  TOBA,
+  USE_FRIDGE,
+  USE_GYM,
+  USE_LAUNDRY,
+  USE_LIBRARY,
+  VISIT_HRS,
+  ;
+}
+
+enum class Status {
+  AS_AWARDED,
+  AWARD_RED,
+  IMMEDIATE,
+  PROSPECTIVE,
+  QUASHED,
+  REDAPP,
+  SUSPENDED,
+  SUSPEN_EXT,
+  SUSPEN_RED,
+  SUSP_PROSP,
+  ;
+}
+
+data class OffenderOicSanctionRequest(
+  val oicSanctionCode: OicSanctionCode,
+  val status: Status,
+  val effectiveDate: LocalDate,
+  val compensationAmount: Double,
+  val sanctionDays: Long,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisSanctionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisSanctionDto.kt
@@ -35,6 +35,8 @@ data class OffenderOicSanctionRequest(
         PunishmentType.EXTRA_WORK -> OicSanctionCode.EXTW
         PunishmentType.REMOVAL_WING -> OicSanctionCode.REMWIN
         PunishmentType.ADDITIONAL_DAYS, PunishmentType.PROSPECTIVE_DAYS -> OicSanctionCode.ADA
+        PunishmentType.CAUTION -> OicSanctionCode.CAUTION
+        PunishmentType.DAMAGES_OWED -> OicSanctionCode.OTHER
       }
 
     private fun PunishmentSchedule.statusMapper(prospectiveDays: Boolean): Status =
@@ -64,7 +66,7 @@ data class OffenderOicSanctionRequest(
         status = latestSchedule.statusMapper(this.type == PunishmentType.PROSPECTIVE_DAYS),
         effectiveDate = latestSchedule.suspendedUntil ?: latestSchedule.startDate ?: LocalDate.now(),
         sanctionDays = latestSchedule.days.toLong(),
-        compensationAmount = this.stoppagePercentage?.toDouble(),
+        compensationAmount = this.amount ?: this.stoppagePercentage?.toDouble(),
         commentText = this.commentMapper(),
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisSanctionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisSanctionDto.kt
@@ -21,12 +21,12 @@ data class OffenderOicSanctionRequest(
   val effectiveDate: LocalDate,
   val compensationAmount: Double? = null,
   val sanctionDays: Long,
-  val comment: String? = null,
+  val commentText: String? = null,
 ) {
   companion object {
 
-    private fun oicSanctionCodeMapper(punishmentType: PunishmentType): OicSanctionCode =
-      when (punishmentType) {
+    private fun PunishmentType.oicSanctionCodeMapper(): OicSanctionCode =
+      when (this) {
         PunishmentType.PRIVILEGE -> OicSanctionCode.FORFEIT
         PunishmentType.EARNINGS -> OicSanctionCode.STOP_PCT
         PunishmentType.CONFINEMENT -> OicSanctionCode.CC
@@ -60,12 +60,12 @@ data class OffenderOicSanctionRequest(
       val latestSchedule = this.schedule.maxBy { it.createDateTime ?: LocalDateTime.now() }
 
       return OffenderOicSanctionRequest(
-        oicSanctionCode = oicSanctionCodeMapper(punishmentType = this.type),
+        oicSanctionCode = this.type.oicSanctionCodeMapper(),
         status = latestSchedule.statusMapper(this.type == PunishmentType.PROSPECTIVE_DAYS),
         effectiveDate = latestSchedule.suspendedUntil ?: latestSchedule.startDate ?: LocalDate.now(),
         sanctionDays = latestSchedule.days.toLong(),
         compensationAmount = this.stoppagePercentage?.toDouble(),
-        comment = this.commentMapper(),
+        commentText = this.commentMapper(),
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/PrisonApiGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/PrisonApiGateway.kt
@@ -5,8 +5,14 @@ import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 
+interface ISanctions {
+  fun createSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void?
+
+  fun updateSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void?
+}
+
 @Service
-class PrisonApiGateway(private val prisonApiClientCreds: WebClient) {
+class PrisonApiGateway(private val prisonApiClientCreds: WebClient) : ISanctions {
   fun requestAdjudicationCreationData(offenderNo: String): NomisAdjudicationCreationRequest =
     prisonApiClientCreds
       .post()
@@ -77,7 +83,7 @@ class PrisonApiGateway(private val prisonApiClientCreds: WebClient) {
       .bodyToMono<Void>()
       .block()
 
-  fun createSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void? =
+  override fun createSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void? =
     prisonApiClientCreds
       .post()
       .uri("/adjudications/adjudication/$adjudicationNumber/sanctions")
@@ -86,7 +92,7 @@ class PrisonApiGateway(private val prisonApiClientCreds: WebClient) {
       .bodyToMono<Void>()
       .block()
 
-  fun updateSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void? =
+  override fun updateSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void? =
     prisonApiClientCreds
       .put()
       .uri("/adjudications/adjudication/$adjudicationNumber/sanctions")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/PrisonApiGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/PrisonApiGateway.kt
@@ -6,9 +6,16 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 
 interface ISanctions {
+
+  fun createSanction(adjudicationNumber: Long, sanction: OffenderOicSanctionRequest): Long
+
+  fun deleteSanction(adjudicationNumber: Long, sanctionSeq: Long): Void?
+
   fun createSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void?
 
   fun updateSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void?
+
+  fun deleteSanctions(adjudicationNumber: Long): Void?
 }
 
 @Service
@@ -83,6 +90,22 @@ class PrisonApiGateway(private val prisonApiClientCreds: WebClient) : ISanctions
       .bodyToMono<Void>()
       .block()
 
+  override fun createSanction(adjudicationNumber: Long, sanction: OffenderOicSanctionRequest): Long =
+    prisonApiClientCreds
+      .post()
+      .uri("/adjudications/adjudication/$adjudicationNumber/sanction")
+      .bodyValue(sanction)
+      .retrieve()
+      .bodyToMono(object : ParameterizedTypeReference<OffenderOicSanctionResponse>() {})
+      .block()!!.sanctionSeq
+
+  override fun deleteSanction(adjudicationNumber: Long, sanctionSeq: Long): Void? = prisonApiClientCreds
+    .delete()
+    .uri("/adjudications/adjudication/$adjudicationNumber/sanction/$sanctionSeq")
+    .retrieve()
+    .bodyToMono<Void>()
+    .block()
+
   override fun createSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void? =
     prisonApiClientCreds
       .post()
@@ -108,7 +131,7 @@ class PrisonApiGateway(private val prisonApiClientCreds: WebClient) : ISanctions
     .bodyToMono<Void>()
     .block()
 
-  fun deleteSanctions(adjudicationNumber: Long): Void? = prisonApiClientCreds
+  override fun deleteSanctions(adjudicationNumber: Long): Void? = prisonApiClientCreds
     .delete()
     .uri("/adjudications/adjudication/$adjudicationNumber/sanctions")
     .retrieve()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/PrisonApiGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/PrisonApiGateway.kt
@@ -76,4 +76,36 @@ class PrisonApiGateway(private val prisonApiClientCreds: WebClient) {
       .retrieve()
       .bodyToMono<Void>()
       .block()
+
+  fun createSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void? =
+    prisonApiClientCreds
+      .post()
+      .uri("/adjudications/adjudication/$adjudicationNumber/sanctions")
+      .bodyValue(sanctions)
+      .retrieve()
+      .bodyToMono<Void>()
+      .block()
+
+  fun updateSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void? =
+    prisonApiClientCreds
+      .put()
+      .uri("/adjudications/adjudication/$adjudicationNumber/sanctions")
+      .bodyValue(sanctions)
+      .retrieve()
+      .bodyToMono<Void>()
+      .block()
+
+  fun quashSanctions(adjudicationNumber: Long): Void? = prisonApiClientCreds
+    .put()
+    .uri("/adjudications/adjudication/$adjudicationNumber/sanctions/quash")
+    .retrieve()
+    .bodyToMono<Void>()
+    .block()
+
+  fun deleteSanctions(adjudicationNumber: Long): Void? = prisonApiClientCreds
+    .delete()
+    .uri("/adjudications/adjudication/$adjudicationNumber/sanctions")
+    .retrieve()
+    .bodyToMono<Void>()
+    .block()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/PrisonApiGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/PrisonApiGateway.kt
@@ -5,21 +5,8 @@ import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 
-interface ISanctions {
-
-  fun createSanction(adjudicationNumber: Long, sanction: OffenderOicSanctionRequest): Long
-
-  fun deleteSanction(adjudicationNumber: Long, sanctionSeq: Long): Void?
-
-  fun createSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void?
-
-  fun updateSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void?
-
-  fun deleteSanctions(adjudicationNumber: Long): Void?
-}
-
 @Service
-class PrisonApiGateway(private val prisonApiClientCreds: WebClient) : ISanctions {
+class PrisonApiGateway(private val prisonApiClientCreds: WebClient) {
   fun requestAdjudicationCreationData(offenderNo: String): NomisAdjudicationCreationRequest =
     prisonApiClientCreds
       .post()
@@ -90,7 +77,7 @@ class PrisonApiGateway(private val prisonApiClientCreds: WebClient) : ISanctions
       .bodyToMono<Void>()
       .block()
 
-  override fun createSanction(adjudicationNumber: Long, sanction: OffenderOicSanctionRequest): Long =
+  fun createSanction(adjudicationNumber: Long, sanction: OffenderOicSanctionRequest): Long =
     prisonApiClientCreds
       .post()
       .uri("/adjudications/adjudication/$adjudicationNumber/sanction")
@@ -99,14 +86,14 @@ class PrisonApiGateway(private val prisonApiClientCreds: WebClient) : ISanctions
       .bodyToMono(object : ParameterizedTypeReference<OffenderOicSanctionResponse>() {})
       .block()!!.sanctionSeq
 
-  override fun deleteSanction(adjudicationNumber: Long, sanctionSeq: Long): Void? = prisonApiClientCreds
+  fun deleteSanction(adjudicationNumber: Long, sanctionSeq: Long): Void? = prisonApiClientCreds
     .delete()
     .uri("/adjudications/adjudication/$adjudicationNumber/sanction/$sanctionSeq")
     .retrieve()
     .bodyToMono<Void>()
     .block()
 
-  override fun createSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void? =
+  fun createSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void? =
     prisonApiClientCreds
       .post()
       .uri("/adjudications/adjudication/$adjudicationNumber/sanctions")
@@ -115,7 +102,7 @@ class PrisonApiGateway(private val prisonApiClientCreds: WebClient) : ISanctions
       .bodyToMono<Void>()
       .block()
 
-  override fun updateSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void? =
+  fun updateSanctions(adjudicationNumber: Long, sanctions: List<OffenderOicSanctionRequest>): Void? =
     prisonApiClientCreds
       .put()
       .uri("/adjudications/adjudication/$adjudicationNumber/sanctions")
@@ -131,7 +118,7 @@ class PrisonApiGateway(private val prisonApiClientCreds: WebClient) : ISanctions
     .bodyToMono<Void>()
     .block()
 
-  override fun deleteSanctions(adjudicationNumber: Long): Void? = prisonApiClientCreds
+  fun deleteSanctions(adjudicationNumber: Long): Void? = prisonApiClientCreds
     .delete()
     .uri("/adjudications/adjudication/$adjudicationNumber/sanctions")
     .retrieve()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/AmendHearingOutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/AmendHearingOutcomeService.kt
@@ -18,6 +18,7 @@ class AmendHearingOutcomeService(
   private val referralService: ReferralService,
   private val completedHearingService: CompletedHearingService,
   private val reportedAdjudicationService: ReportedAdjudicationService,
+  private val punishmentsService: PunishmentsService,
 ) {
 
   fun amendHearingOutcome(
@@ -64,15 +65,21 @@ class AmendHearingOutcomeService(
 
     val outcomeCodeToAmend = currentStatus.mapStatusToOutcomeCode() ?: return updated
 
-    return outcomeService.amendOutcomeViaService(
-      adjudicationNumber = adjudicationNumber,
-      outcomeCodeToAmend = outcomeCodeToAmend,
-      details = amendHearingOutcomeRequest.details,
-      notProceedReason = amendHearingOutcomeRequest.notProceedReason,
-      amount = amendHearingOutcomeRequest.amount,
-      damagesOwed = amendHearingOutcomeRequest.damagesOwed,
-      caution = amendHearingOutcomeRequest.caution,
-    )
+    return if (outcomeCodeToAmend == OutcomeCode.CHARGE_PROVED) {
+      punishmentsService.amendPunishmentsFromChargeProvedIfApplicable(
+        adjudicationNumber = adjudicationNumber,
+        caution = amendHearingOutcomeRequest.caution!!,
+        damagesOwed = amendHearingOutcomeRequest.damagesOwed,
+        amount = amendHearingOutcomeRequest.amount,
+      )
+    } else {
+      outcomeService.amendOutcomeViaService(
+        adjudicationNumber = adjudicationNumber,
+        outcomeCodeToAmend = outcomeCodeToAmend,
+        details = amendHearingOutcomeRequest.details,
+        notProceedReason = amendHearingOutcomeRequest.notProceedReason,
+      )
+    }
   }
 
   private fun removeAndCreate(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/NomisOutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/NomisOutcomeService.kt
@@ -79,8 +79,8 @@ class NomisOutcomeService(
         }
         return
       }
-      if (outcome.createOutcome()) deleteHearingResult(adjudicationNumber = adjudicationNumber, hearing = it, outcome = outcome)
       if (outcome.code == OutcomeCode.CHARGE_PROVED) prisonApiGateway.deleteSanctions(adjudicationNumber = adjudicationNumber)
+      if (outcome.createOutcome()) deleteHearingResult(adjudicationNumber = adjudicationNumber, hearing = it, outcome = outcome)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/NomisOutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/NomisOutcomeService.kt
@@ -41,6 +41,8 @@ class NomisOutcomeService(
           oicHearingId = oicHearingId,
         )
 
+        if (outcome.code == OutcomeCode.QUASHED) prisonApiGateway.quashSanctions(adjudicationNumber = adjudicationNumber)
+
         return oicHearingId
       }
 
@@ -78,6 +80,7 @@ class NomisOutcomeService(
         return
       }
       if (outcome.createOutcome()) deleteHearingResult(adjudicationNumber = adjudicationNumber, hearing = it, outcome = outcome)
+      if (outcome.code == OutcomeCode.CHARGE_PROVED) prisonApiGateway.deleteSanctions(adjudicationNumber = adjudicationNumber)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
@@ -124,9 +124,6 @@ class OutcomeService(
     outcomeCodeToAmend: OutcomeCode,
     details: String? = null,
     notProceedReason: NotProceedReason? = null,
-    amount: Double? = null,
-    damagesOwed: Boolean? = null,
-    caution: Boolean? = null,
   ): ReportedAdjudicationDto {
     val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber)
 
@@ -138,9 +135,6 @@ class OutcomeService(
       adjudicationNumber = adjudicationNumber,
       details = details,
       reason = notProceedReason,
-      amount = amount,
-      damagesOwed = damagesOwed,
-      caution = caution,
     )
   }
 
@@ -167,8 +161,6 @@ class OutcomeService(
       code = code,
       details = details,
       reason = reason,
-      amount = amount,
-      caution = caution,
       quashedReason = quashedReason,
     ).also {
       it.oicHearingId = nomisOutcomeService.createHearingResultIfApplicable(
@@ -180,6 +172,14 @@ class OutcomeService(
 
     reportedAdjudication.outcomes.add(outcomeToCreate)
 
+    if (outcomeToCreate.code == OutcomeCode.CHARGE_PROVED) {
+      punishmentsService.createPunishmentsFromChargeProvedIfApplicable(
+        adjudicationNumber = adjudicationNumber,
+        caution = caution!!,
+        amount = amount,
+      )
+    }
+
     return saveToDto(reportedAdjudication)
   }
 
@@ -188,9 +188,6 @@ class OutcomeService(
     details: String? = null,
     reason: NotProceedReason? = null,
     quashedReason: QuashedReason? = null,
-    amount: Double? = null,
-    damagesOwed: Boolean? = null,
-    caution: Boolean? = null,
   ): ReportedAdjudicationDto {
     val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber)
 
@@ -200,14 +197,12 @@ class OutcomeService(
           details?.let { updated -> it.details = updated }
           reason?.let { updated -> it.reason = updated }
         }
+
         OutcomeCode.QUASHED -> {
           details?.let { updated -> it.details = updated }
           quashedReason?.let { updated -> it.quashedReason = updated }
         }
-        OutcomeCode.CHARGE_PROVED -> {
-          damagesOwed?.let { _ -> it.amount = amount }
-          caution?.let { updated -> it.caution = updated }
-        }
+
         OutcomeCode.REFER_POLICE, OutcomeCode.REFER_INAD, OutcomeCode.DISMISSED -> details?.let { updated -> it.details = updated }
         else -> {}
       }
@@ -246,7 +241,7 @@ class OutcomeService(
 
   fun getOutcomes(adjudicationNumber: Long): List<CombinedOutcomeDto> {
     val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber)
-    return reportedAdjudication.outcomes.createCombinedOutcomes()
+    return reportedAdjudication.outcomes.createCombinedOutcomes(reportedAdjudication.punishments)
   }
 
   fun getLatestOutcome(adjudicationNumber: Long): Outcome? = findByAdjudicationNumber(adjudicationNumber).latestOutcome()
@@ -291,7 +286,7 @@ class OutcomeService(
     fun Outcome?.canAmendViaService(hasHearings: Boolean): Outcome {
       this ?: throw EntityNotFoundException("no latest outcome to amend")
 
-      if (listOf(OutcomeCode.QUASHED, OutcomeCode.SCHEDULE_HEARING).any { it == this.code } ||
+      if (listOf(OutcomeCode.QUASHED, OutcomeCode.SCHEDULE_HEARING, OutcomeCode.CHARGE_PROVED).any { it == this.code } ||
         (!hasHearings && listOf(OutcomeCode.NOT_PROCEED, OutcomeCode.REFER_POLICE).any { it == this.code })
       ) {
         throw ValidationException("unable to amend via this function")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
@@ -232,6 +232,8 @@ class OutcomeService(
     reportedAdjudication.outcomes.remove(outcomeToDelete)
     reportedAdjudication.calculateStatus()
 
+    if (outcomeToDelete.code == OutcomeCode.CHARGE_PROVED) reportedAdjudication.punishments.clear()
+
     nomisOutcomeService.deleteHearingResultIfApplicable(
       adjudicationNumber = adjudicationNumber,
       hearing = reportedAdjudication.getLatestHearing(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
@@ -174,7 +174,7 @@ class OutcomeService(
 
     if (outcomeToCreate.code == OutcomeCode.CHARGE_PROVED) {
       punishmentsService.createPunishmentsFromChargeProvedIfApplicable(
-        adjudicationNumber = adjudicationNumber,
+        reportedAdjudication = reportedAdjudication,
         caution = caution!!,
         amount = amount,
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeService.kt
@@ -23,6 +23,7 @@ class OutcomeService(
   offenceCodeLookupService: OffenceCodeLookupService,
   authenticationFacade: AuthenticationFacade,
   private val nomisOutcomeService: NomisOutcomeService,
+  private val punishmentsService: PunishmentsService,
 ) : ReportedAdjudicationBaseService(
   reportedAdjudicationRepository,
   offenceCodeLookupService,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
@@ -59,13 +59,11 @@ class PunishmentsService(
       }
     }
 
-    val sanctionsToCreate = reportedAdjudication.mapToSanctions().toMutableList().also {
-      it.addAll(createSanctionsFromOutcome(reportedAdjudication.latestOutcome()))
-    }
-
     prisonApiGateway.createSanctions(
       adjudicationNumber = adjudicationNumber,
-      sanctions = sanctionsToCreate,
+      sanctions = reportedAdjudication.mapToSanctions().toMutableList().also {
+        it.addAll(createSanctionsFromOutcome(reportedAdjudication.latestOutcome()))
+      },
     )
 
     return saveToDto(reportedAdjudication)
@@ -108,13 +106,11 @@ class PunishmentsService(
       }
     }
 
-    val sanctionsToUpdate = reportedAdjudication.mapToSanctions().toMutableList().also {
-      it.addAll(createSanctionsFromOutcome(reportedAdjudication.latestOutcome()))
-    }
-
     prisonApiGateway.updateSanctions(
       adjudicationNumber = adjudicationNumber,
-      sanctions = sanctionsToUpdate,
+      sanctions = reportedAdjudication.mapToSanctions().toMutableList().also {
+        it.addAll(createSanctionsFromOutcome(reportedAdjudication.latestOutcome()))
+      },
     )
 
     return saveToDto(reportedAdjudication)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
@@ -186,7 +186,7 @@ class PunishmentsService(
             oicSanctionCode = OicSanctionCode.CAUTION,
             effectiveDate = LocalDate.now(),
             status = Status.IMMEDIATE,
-            sanctionDays = 0, //TO REVIEW
+            sanctionDays = 0, // TO REVIEW
           ),
         )
       }
@@ -198,7 +198,7 @@ class PunishmentsService(
           oicSanctionCode = OicSanctionCode.OTHER,
           effectiveDate = LocalDate.now(),
           status = Status.IMMEDIATE,
-          sanctionDays = 0, //TO REVIEW
+          sanctionDays = 0, // TO REVIEW
           compensationAmount = it,
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
@@ -9,15 +9,18 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.PunishmentD
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.PunishmentScheduleDto
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.ReportedAdjudicationDto
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.SuspendedPunishmentDto
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Outcome
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PrivilegeType
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Punishment
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentSchedule
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentType
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudication
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.ISanctions
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OffenderOicSanctionRequest
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OffenderOicSanctionRequest.Companion.mapPunishmentToSanction
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonApiGateway
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OicSanctionCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.Status
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.OffenceCodeLookupService
@@ -30,7 +33,7 @@ class PunishmentsService(
   reportedAdjudicationRepository: ReportedAdjudicationRepository,
   offenceCodeLookupService: OffenceCodeLookupService,
   authenticationFacade: AuthenticationFacade,
-  private val prisonApiGateway: PrisonApiGateway,
+  private val prisonApiGateway: ISanctions,
 ) : ReportedAdjudicationBaseService(
   reportedAdjudicationRepository,
   offenceCodeLookupService,
@@ -56,9 +59,17 @@ class PunishmentsService(
       }
     }
 
+    val sanctionsToCreate = reportedAdjudication.mapToSanctions().toMutableList()
+
+    sanctionsToCreate.addAll(
+      createSanctionsFromOutcome(
+        reportedAdjudication.latestOutcome(),
+      ),
+    )
+
     prisonApiGateway.createSanctions(
       adjudicationNumber = adjudicationNumber,
-      sanctions = reportedAdjudication.mapToSanctions(),
+      sanctions = sanctionsToCreate,
     )
 
     return saveToDto(reportedAdjudication)
@@ -166,6 +177,36 @@ class PunishmentsService(
       }
     }
 
+  private fun createSanctionsFromOutcome(outcome: Outcome?): List<OffenderOicSanctionRequest> {
+    val sanctionsToCreate = mutableListOf<OffenderOicSanctionRequest>()
+    outcome?.caution?.let {
+      if (it) {
+        sanctionsToCreate.add(
+          OffenderOicSanctionRequest(
+            oicSanctionCode = OicSanctionCode.CAUTION,
+            effectiveDate = LocalDate.now(),
+            status = Status.IMMEDIATE,
+            sanctionDays = 0, //TO REVIEW
+          ),
+        )
+      }
+    }
+
+    outcome?.amount?.let {
+      sanctionsToCreate.add(
+        OffenderOicSanctionRequest(
+          oicSanctionCode = OicSanctionCode.OTHER,
+          effectiveDate = LocalDate.now(),
+          status = Status.IMMEDIATE,
+          sanctionDays = 0, //TO REVIEW
+          compensationAmount = it,
+        ),
+      )
+    }
+
+    return sanctionsToCreate
+  }
+
   private fun activateSuspendedPunishment(adjudicationNumber: Long, punishmentRequest: PunishmentRequest): Punishment {
     val activatedFromReport = findByAdjudicationNumber(punishmentRequest.activatedFrom!!)
     val suspendedPunishment = activatedFromReport.punishments.getSuspendedPunishment(punishmentRequest.id!!)
@@ -194,11 +235,13 @@ class PunishmentsService(
   companion object {
 
     fun ReportedAdjudication.mapToSanctions(): List<OffenderOicSanctionRequest> =
-      this.punishments.map { it.mapPunishmentToSanction(this.latestOutcome()?.amount) }
+      this.punishments.map { it.mapPunishmentToSanction() }
 
     fun List<PunishmentSchedule>.latestSchedule() = this.maxBy { it.createDateTime!! }
+
     fun List<Punishment>.suspendedPunishmentsToActivate() =
       this.filter { p -> p.activatedFrom == null && p.activatedBy == null && p.schedule.latestSchedule().suspendedUntil != null }
+
     fun List<Punishment>.getSuspendedPunishment(id: Long): Punishment = this.firstOrNull { it.id == id } ?: throw EntityNotFoundException("suspended punishment not found")
 
     fun PunishmentSchedule.hasScheduleBeenUpdated(punishmentRequest: PunishmentRequest): Boolean =
@@ -207,6 +250,7 @@ class PunishmentsService(
 
     fun List<Punishment>.getPunishmentToAmend(id: Long) =
       this.firstOrNull { it.id == id } ?: throw EntityNotFoundException("Punishment $id is not associated with ReportedAdjudication")
+
     fun PunishmentRequest.validateRequest() {
       when (this.type) {
         PunishmentType.PRIVILEGE -> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
@@ -24,7 +24,6 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.Status
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.OffenceCodeLookupService
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.OutcomeService.Companion.latestOutcome
 import java.time.LocalDate
 
 @Transactional
@@ -39,6 +38,26 @@ class PunishmentsService(
   offenceCodeLookupService,
   authenticationFacade,
 ) {
+
+  fun createCaution(adjudicationNumber: Long) {
+    TODO("implement me")
+  }
+
+  fun createDamagesOwed(adjudicationNumber: Long) {
+    TODO("implement me")
+  }
+
+  fun deleteCaution(adjudicationNumber: Long) {
+    TODO("implement me")
+  }
+
+  fun deleteDamagesOwed(adjudicationNumber: Long) {
+    TODO("implement me")
+  }
+
+  fun amendDamagesOwed(adjudicationNumber: Long) {
+    TODO("implement me")
+  }
 
   fun create(
     adjudicationNumber: Long,
@@ -61,9 +80,7 @@ class PunishmentsService(
 
     prisonApiGateway.createSanctions(
       adjudicationNumber = adjudicationNumber,
-      sanctions = reportedAdjudication.mapToSanctions().toMutableList().also {
-        it.addAll(createSanctionsFromOutcome(reportedAdjudication.latestOutcome()))
-      },
+      sanctions = reportedAdjudication.mapToSanctions(),
     )
 
     return saveToDto(reportedAdjudication)
@@ -108,10 +125,10 @@ class PunishmentsService(
 
     prisonApiGateway.updateSanctions(
       adjudicationNumber = adjudicationNumber,
-      sanctions = reportedAdjudication.mapToSanctions().toMutableList().also {
-        it.addAll(createSanctionsFromOutcome(reportedAdjudication.latestOutcome()))
-      },
+      sanctions = reportedAdjudication.mapToSanctions(),
     )
+
+    // TODO potentially need to maintain damages owed at this point as it will be removed via update.
 
     return saveToDto(reportedAdjudication)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Punishm
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentSchedule
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentType
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonApiGateway
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.OffenceCodeLookupService
@@ -25,6 +26,7 @@ class PunishmentsService(
   reportedAdjudicationRepository: ReportedAdjudicationRepository,
   offenceCodeLookupService: OffenceCodeLookupService,
   authenticationFacade: AuthenticationFacade,
+  private val prisonApiGateway: PrisonApiGateway,
 ) : ReportedAdjudicationBaseService(
   reportedAdjudicationRepository,
   offenceCodeLookupService,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
@@ -16,10 +16,10 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Punishm
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentType
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudication
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
-import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.ISanctions
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OffenderOicSanctionRequest
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OffenderOicSanctionRequest.Companion.mapPunishmentToSanction
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OicSanctionCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonApiGateway
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.Status
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.security.AuthenticationFacade
@@ -32,18 +32,14 @@ class PunishmentsService(
   reportedAdjudicationRepository: ReportedAdjudicationRepository,
   offenceCodeLookupService: OffenceCodeLookupService,
   authenticationFacade: AuthenticationFacade,
-  private val prisonApiGateway: ISanctions,
+  private val prisonApiGateway: PrisonApiGateway,
 ) : ReportedAdjudicationBaseService(
   reportedAdjudicationRepository,
   offenceCodeLookupService,
   authenticationFacade,
 ) {
 
-  fun createCaution(adjudicationNumber: Long) {
-    TODO("implement me")
-  }
-
-  fun createDamagesOwed(adjudicationNumber: Long) {
+  fun createCaution(adjudicationNumber: Long): Long {
     TODO("implement me")
   }
 
@@ -51,11 +47,15 @@ class PunishmentsService(
     TODO("implement me")
   }
 
-  fun deleteDamagesOwed(adjudicationNumber: Long) {
+  fun createDamagesOwed(adjudicationNumber: Long): Long {
     TODO("implement me")
   }
 
-  fun amendDamagesOwed(adjudicationNumber: Long) {
+  fun amendDamagesOwed(adjudicationNumber: Long): Long {
+    TODO("implement me")
+  }
+
+  fun deleteDamagesOwed(adjudicationNumber: Long) {
     TODO("implement me")
   }
 

--- a/src/main/resources/db/migration/V60__charge_proved_sanction_seq.sql
+++ b/src/main/resources/db/migration/V60__charge_proved_sanction_seq.sql
@@ -1,2 +1,0 @@
-ALTER TABLE outcome ADD COLUMN damages_owed_sanction_seq bigint;
-ALTER TABLE outcome ADD COLUMN caution_sanction_seq bigint;

--- a/src/main/resources/db/migration/V60__charge_proved_sanction_seq.sql
+++ b/src/main/resources/db/migration/V60__charge_proved_sanction_seq.sql
@@ -1,0 +1,2 @@
+ALTER TABLE outcome ADD COLUMN damages_owed_sanction_seq bigint;
+ALTER TABLE outcome ADD COLUMN caution_sanction_seq bigint;

--- a/src/main/resources/db/migration/V60__modify_caution_and_damages_owed.sql
+++ b/src/main/resources/db/migration/V60__modify_caution_and_damages_owed.sql
@@ -1,0 +1,5 @@
+ALTER TABLE outcome DROP COLUMN amount;
+ALTER TABLE outcome DROP COLUMN caution;
+
+ALTER TABLE punishment ADD COLUMN sanction_seq bigint;
+ALTER TABLE punishment ADD COLUMN amount decimal(10,2);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/AmendHearingOutcomesIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/AmendHearingOutcomesIntTest.kt
@@ -113,6 +113,8 @@ class AmendHearingOutcomesIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubAmendHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubDeleteSanction(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
     initDataForHearings().createHearing().createChargeProved()
 
@@ -221,6 +223,8 @@ class AmendHearingOutcomesIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubDeleteHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubDeleteSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
     initDataForHearings().createHearing().also {
       when (from) {
@@ -322,6 +326,8 @@ class AmendHearingOutcomesIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubAmendHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubDeleteSanction(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
     initDataForHearings().createHearing().createChargeProved()
 
@@ -391,6 +397,7 @@ class AmendHearingOutcomesIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubDeleteHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubDeleteSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
     initDataForHearings().createHearing().createChargeProved().createPunishments()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
@@ -5,6 +5,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.draft.DraftAdjudicationResponse
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.draft.IncidentRoleRequest
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.reported.PunishmentRequest
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.reported.ReportedAdjudicationResponse
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.DamageCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.EvidenceCode
@@ -12,12 +13,14 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Hearing
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomePlea
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.NotProceedReason
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentType
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.QuashedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.WitnessCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OicHearingType
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration.wiremock.PrisonApiMockServer
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.utils.JwtAuthHelper
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class IntegrationTestData(
@@ -644,6 +647,27 @@ class IntegrationTestData(
       .returnResult(ReportedAdjudicationResponse::class.java)
       .responseBody
       .blockFirst()!!
+  }
+
+  fun createPunishments(
+    testDataSet: AdjudicationIntTestDataSet,
+  ): WebTestClient.ResponseSpec {
+    return webTestClient.post()
+      .uri("/reported-adjudications/${testDataSet.adjudicationNumber}/punishments")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .bodyValue(
+        mapOf(
+          "punishments" to
+            listOf(
+              PunishmentRequest(
+                type = PunishmentType.CONFINEMENT,
+                days = 10,
+                suspendedUntil = LocalDate.now(),
+              ),
+            ),
+        ),
+      )
+      .exchange()
   }
 
   fun createNotProceed(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
@@ -631,6 +631,7 @@ class IntegrationTestData(
 
   fun createChargeProved(
     testDataSet: AdjudicationIntTestDataSet,
+    caution: Boolean? = true,
   ): ReportedAdjudicationResponse {
     return webTestClient.post()
       .uri("/reported-adjudications/${testDataSet.adjudicationNumber}/complete-hearing/charge-proved")
@@ -640,7 +641,7 @@ class IntegrationTestData(
           "adjudicator" to "test",
           "plea" to HearingOutcomePlea.NOT_GUILTY,
           "amount" to 100.50,
-          "caution" to true,
+          "caution" to caution,
         ),
       )
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestScenarioBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestScenarioBuilder.kt
@@ -94,9 +94,11 @@ class IntegrationTestScenario(
 
   fun createChargeProved(
     overrideTestDataSet: AdjudicationIntTestDataSet = testAdjudicationDataSet,
+    caution: Boolean? = true,
   ): IntegrationTestScenario {
     intTestData.createChargeProved(
       overrideTestDataSet,
+      caution,
     )
     return this
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestScenarioBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestScenarioBuilder.kt
@@ -101,6 +101,12 @@ class IntegrationTestScenario(
     return this
   }
 
+  fun createPunishments(): IntegrationTestScenario {
+    intTestData.createPunishments(testAdjudicationDataSet)
+
+    return this
+  }
+
   fun createNotProceed(): IntegrationTestScenario {
     intTestData.createNotProceed(
       testAdjudicationDataSet,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
@@ -443,4 +443,26 @@ class OutcomeIntTest : IntegrationTestBase() {
       .jsonPath("$.reportedAdjudication.outcomes[0].outcome.referralOutcome").exists()
       .jsonPath("$.reportedAdjudication.outcomes[0].outcome.referralOutcome.code").isEqualTo(OutcomeCode.SCHEDULE_HEARING.name)
   }
+
+  @Test
+  fun `remove charge proved with punishments removes punishments `() {
+    prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubDeleteSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+
+    initDataForOutcome()
+      .createHearing(dateTimeOfHearing = LocalDateTime.now())
+      .createChargeProved()
+      .createPunishments()
+
+    webTestClient.delete()
+      .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber}/remove-completed-hearing")
+      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.reportedAdjudication.punishments.size()")
+      .isEqualTo(0)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
@@ -223,6 +223,7 @@ class OutcomeIntTest : IntegrationTestBase() {
   @Test
   fun `remove completed hearing outcome `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubDeleteHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     initDataForOutcome().createHearing().createChargeProved()
 
@@ -270,6 +271,10 @@ class OutcomeIntTest : IntegrationTestBase() {
   @Test
   fun `remove quashed outcome `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubDeleteHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubQuashSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+
     initDataForOutcome().createHearing().createChargeProved().createQuashed()
 
     webTestClient.delete()
@@ -332,7 +337,9 @@ class OutcomeIntTest : IntegrationTestBase() {
   @Test
   fun `amend outcome - quashed `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubAmendHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubQuashSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
     initDataForOutcome().createHearing().createChargeProved().createQuashed()
 
@@ -359,6 +366,9 @@ class OutcomeIntTest : IntegrationTestBase() {
   @Test
   fun `amend outcome - not proceed when its a referral outcome`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubDeleteHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+
     initDataForHearings().createHearing().createReferral(HearingOutcomeCode.REFER_POLICE).createOutcomeNotProceed()
 
     webTestClient.put()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
@@ -225,6 +225,8 @@ class OutcomeIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubDeleteHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubDeleteSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+
     initDataForOutcome().createHearing().createChargeProved()
 
     webTestClient.delete()
@@ -271,9 +273,11 @@ class OutcomeIntTest : IntegrationTestBase() {
   @Test
   fun `remove quashed outcome `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubDeleteHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubQuashSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubDeleteSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
     initDataForOutcome().createHearing().createChargeProved().createQuashed()
 
@@ -366,8 +370,9 @@ class OutcomeIntTest : IntegrationTestBase() {
   @Test
   fun `amend outcome - not proceed when its a referral outcome`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    prisonApiMockServer.stubDeleteHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubAmendHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
     initDataForHearings().createHearing().createReferral(HearingOutcomeCode.REFER_POLICE).createOutcomeNotProceed()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
@@ -225,6 +225,7 @@ class OutcomeIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubDeleteHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubDeleteSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
     initDataForOutcome().createHearing().createChargeProved()
@@ -276,6 +277,7 @@ class OutcomeIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubDeleteHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubQuashSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubDeleteSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
@@ -344,6 +346,7 @@ class OutcomeIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubAmendHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubQuashSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
     initDataForOutcome().createHearing().createChargeProved().createQuashed()
 
@@ -465,6 +468,7 @@ class OutcomeIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubDeleteSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
     initDataForOutcome()
       .createHearing(dateTimeOfHearing = LocalDateTime.now())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/PunishmentsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/PunishmentsIntTest.kt
@@ -20,8 +20,9 @@ class PunishmentsIntTest : IntegrationTestBase() {
   @Test
   fun `create punishments `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    initDataForOutcome().createHearing().createChargeProved()
+    initDataForOutcome().createHearing().createChargeProved(caution = false)
 
     createPunishments()
       .expectStatus().isCreated
@@ -38,9 +39,10 @@ class PunishmentsIntTest : IntegrationTestBase() {
   @Test
   fun `update punishments - amends one record, removes a record, and creates a record`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubUpdateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    initDataForOutcome().createHearing().createChargeProved()
+    initDataForOutcome().createHearing().createChargeProved(caution = false)
 
     val suspendedUntil = LocalDate.now().plusMonths(1)
     val formattedDate = suspendedUntil.format(DateTimeFormatter.ISO_DATE)
@@ -115,10 +117,12 @@ class PunishmentsIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubCreateSanctions(IntegrationTestData.ADJUDICATION_2.adjudicationNumber)
     prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanction(IntegrationTestData.ADJUDICATION_2.adjudicationNumber)
 
-    initDataForOutcome().createHearing().createChargeProved()
+    initDataForOutcome().createHearing().createChargeProved(caution = false)
     initDataForOutcome(adjudication = IntegrationTestData.ADJUDICATION_2).createHearing(dateTimeOfHearing = LocalDateTime.now().plusDays(1), overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
-      .createChargeProved(overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
+      .createChargeProved(overrideTestDataSet = IntegrationTestData.ADJUDICATION_2, caution = false)
 
     val result = createPunishments(type = PunishmentType.PROSPECTIVE_DAYS)
       .returnResult(ReportedAdjudicationResponse::class.java)
@@ -166,10 +170,12 @@ class PunishmentsIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubCreateSanctions(IntegrationTestData.ADJUDICATION_2.adjudicationNumber)
     prisonApiMockServer.stubUpdateSanctions(IntegrationTestData.ADJUDICATION_2.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanction(IntegrationTestData.ADJUDICATION_2.adjudicationNumber)
 
-    initDataForOutcome().createHearing().createChargeProved()
+    initDataForOutcome().createHearing().createChargeProved(caution = false)
     initDataForOutcome(adjudication = IntegrationTestData.ADJUDICATION_2).createHearing(dateTimeOfHearing = LocalDateTime.now().plusDays(1), overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
-      .createChargeProved(overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
+      .createChargeProved(overrideTestDataSet = IntegrationTestData.ADJUDICATION_2, caution = false)
 
     val result = createPunishments(type = PunishmentType.PROSPECTIVE_DAYS)
       .returnResult(ReportedAdjudicationResponse::class.java)
@@ -214,7 +220,11 @@ class PunishmentsIntTest : IntegrationTestBase() {
   @Test
   fun `get suspended punishments `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
-    initDataForOutcome().createHearing().createChargeProved()
+    prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+
+    initDataForOutcome().createHearing().createChargeProved(caution = false)
 
     createPunishments()
       .expectStatus().isCreated

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/PunishmentsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/PunishmentsIntTest.kt
@@ -20,6 +20,7 @@ class PunishmentsIntTest : IntegrationTestBase() {
   @Test
   fun `create punishments `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     initDataForOutcome().createHearing().createChargeProved()
 
     createPunishments()
@@ -37,6 +38,8 @@ class PunishmentsIntTest : IntegrationTestBase() {
   @Test
   fun `update punishments - amends one record, removes a record, and creates a record`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubUpdateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     initDataForOutcome().createHearing().createChargeProved()
 
     val suspendedUntil = LocalDate.now().plusMonths(1)
@@ -110,6 +113,8 @@ class PunishmentsIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.ADJUDICATION_2.adjudicationNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.ADJUDICATION_2.adjudicationNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanctions(IntegrationTestData.ADJUDICATION_2.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
 
     initDataForOutcome().createHearing().createChargeProved()
     initDataForOutcome(adjudication = IntegrationTestData.ADJUDICATION_2).createHearing(dateTimeOfHearing = LocalDateTime.now().plusDays(1), overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
@@ -158,6 +163,9 @@ class PunishmentsIntTest : IntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.ADJUDICATION_2.adjudicationNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.ADJUDICATION_2.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.adjudicationNumber)
+    prisonApiMockServer.stubCreateSanctions(IntegrationTestData.ADJUDICATION_2.adjudicationNumber)
+    prisonApiMockServer.stubUpdateSanctions(IntegrationTestData.ADJUDICATION_2.adjudicationNumber)
 
     initDataForOutcome().createHearing().createChargeProved()
     initDataForOutcome(adjudication = IntegrationTestData.ADJUDICATION_2).createHearing(dateTimeOfHearing = LocalDateTime.now().plusDays(1), overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/wiremock/PrisonApiMockServer.kt
@@ -248,4 +248,48 @@ class PrisonApiMockServer : WireMockServer {
         ),
     )
   }
+
+  fun createSanctions(adjudicationNumber: Long) {
+    stubFor(
+      post(urlEqualTo("/api/adjudications/adjudication/$adjudicationNumber/sanctions"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200),
+        ),
+    )
+  }
+
+  fun updateSanctions(adjudicationNumber: Long) {
+    stubFor(
+      put(urlEqualTo("/api/adjudications/adjudication/$adjudicationNumber/sanctions"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200),
+        ),
+    )
+  }
+
+  fun stubQuashSanctions(adjudicationNumber: Long) {
+    stubFor(
+      put(urlEqualTo("/api/adjudications/adjudication/$adjudicationNumber/sanctions/quash"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200),
+        ),
+    )
+  }
+
+  fun stubDeleteSanctions(adjudicationNumber: Long) {
+    stubFor(
+      delete(urlEqualTo("/api/adjudications/adjudication/$adjudicationNumber/sanctions"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200),
+        ),
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/wiremock/PrisonApiMockServer.kt
@@ -260,6 +260,22 @@ class PrisonApiMockServer : WireMockServer {
     )
   }
 
+  fun stubCreateSanction(adjudicationNumber: Long) {
+    stubFor(
+      post(urlEqualTo("/api/adjudications/adjudication/$adjudicationNumber/sanction"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody(
+              JSONObject()
+                .put("sanctionSeq", "1")
+                .toString(),
+            ),
+        ),
+    )
+  }
+
   fun stubUpdateSanctions(adjudicationNumber: Long) {
     stubFor(
       put(urlEqualTo("/api/adjudications/adjudication/$adjudicationNumber/sanctions"))
@@ -285,6 +301,17 @@ class PrisonApiMockServer : WireMockServer {
   fun stubDeleteSanctions(adjudicationNumber: Long) {
     stubFor(
       delete(urlEqualTo("/api/adjudications/adjudication/$adjudicationNumber/sanctions"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200),
+        ),
+    )
+  }
+
+  fun stubDeleteSanction(adjudicationNumber: Long) {
+    stubFor(
+      delete(urlEqualTo("/api/adjudications/adjudication/$adjudicationNumber/sanction/1"))
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/wiremock/PrisonApiMockServer.kt
@@ -249,7 +249,7 @@ class PrisonApiMockServer : WireMockServer {
     )
   }
 
-  fun createSanctions(adjudicationNumber: Long) {
+  fun stubCreateSanctions(adjudicationNumber: Long) {
     stubFor(
       post(urlEqualTo("/api/adjudications/adjudication/$adjudicationNumber/sanctions"))
         .willReturn(
@@ -260,7 +260,7 @@ class PrisonApiMockServer : WireMockServer {
     )
   }
 
-  fun updateSanctions(adjudicationNumber: Long) {
+  fun stubUpdateSanctions(adjudicationNumber: Long) {
     stubFor(
       put(urlEqualTo("/api/adjudications/adjudication/$adjudicationNumber/sanctions"))
         .willReturn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/AmendHearingOutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/AmendHearingOutcomeServiceTest.kt
@@ -30,12 +30,14 @@ class AmendHearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
   private val referralService: ReferralService = mock()
   private val completedHearingService: CompletedHearingService = mock()
   private val reportedAdjudicationService: ReportedAdjudicationService = mock()
+  private val punishmentsService: PunishmentsService = mock()
   private val amendHearingOutcomeService = AmendHearingOutcomeService(
     hearingOutcomeService,
     outcomeService,
     referralService,
     completedHearingService,
     reportedAdjudicationService,
+    punishmentsService,
   )
 
   override fun `throws an entity not found if the reported adjudication for the supplied id does not exists`() {
@@ -71,15 +73,21 @@ class AmendHearingOutcomeServiceTest : ReportedAdjudicationTestBase() {
       )
 
       if (code != HearingOutcomeCode.ADJOURN) {
-        verify(outcomeService, atLeastOnce()).amendOutcomeViaService(
-          adjudicationNumber = 1L,
-          outcomeCodeToAmend = status.mapStatusToOutcomeCode()!!,
-          details = request.details,
-          amount = request.amount,
-          damagesOwed = request.damagesOwed,
-          caution = request.caution,
-          notProceedReason = request.notProceedReason,
-        )
+        if (status == ReportedAdjudicationStatus.CHARGE_PROVED) {
+          verify(punishmentsService, atLeastOnce()).amendPunishmentsFromChargeProvedIfApplicable(
+            adjudicationNumber = 1L,
+            damagesOwed = null,
+            amount = request.amount,
+            caution = request.caution!!,
+          )
+        } else {
+          verify(outcomeService, atLeastOnce()).amendOutcomeViaService(
+            adjudicationNumber = 1L,
+            outcomeCodeToAmend = status.mapStatusToOutcomeCode()!!,
+            details = request.details,
+            notProceedReason = request.notProceedReason,
+          )
+        }
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingServiceTest.kt
@@ -58,6 +58,21 @@ class HearingServiceTest : ReportedAdjudicationTestBase() {
       hearingService.deleteHearing(1)
     }.isInstanceOf(EntityNotFoundException::class.java)
       .hasMessageContaining("ReportedAdjudication not found for 1")
+
+    Assertions.assertThatThrownBy {
+      hearingService.createHearingV1(1, 1, LocalDateTime.now(), OicHearingType.GOV)
+    }.isInstanceOf(EntityNotFoundException::class.java)
+      .hasMessageContaining("ReportedAdjudication not found for 1")
+
+    Assertions.assertThatThrownBy {
+      hearingService.amendHearingV1(1, 1, 1, LocalDateTime.now(), OicHearingType.GOV)
+    }.isInstanceOf(EntityNotFoundException::class.java)
+      .hasMessageContaining("ReportedAdjudication not found for 1")
+
+    Assertions.assertThatThrownBy {
+      hearingService.deleteHearingV1(1, 1)
+    }.isInstanceOf(EntityNotFoundException::class.java)
+      .hasMessageContaining("ReportedAdjudication not found for 1")
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/NomisOutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/NomisOutcomeServiceTest.kt
@@ -99,6 +99,7 @@ class NomisOutcomeServiceTest : ReportedAdjudicationTestBase() {
       )
 
       assertThat(hearingId).isNotNull
+      verify(prisonApiGateway, atLeastOnce()).quashSanctions(any())
       verify(prisonApiGateway, atLeastOnce()).createHearing(any(), any())
       verify(prisonApiGateway, atLeastOnce()).createHearingResult(
         reportedAdjudication.reportNumber,
@@ -424,6 +425,10 @@ class NomisOutcomeServiceTest : ReportedAdjudicationTestBase() {
         hearing = reportedAdjudication.getLatestHearing(),
         outcome = reportedAdjudication.latestOutcome()!!,
       )
+
+      if (code == OutcomeCode.CHARGE_PROVED) {
+        verify(prisonApiGateway, atLeastOnce()).deleteSanctions(any())
+      }
 
       verify(prisonApiGateway, never()).deleteHearing(reportedAdjudication.reportNumber, 100L)
       verify(prisonApiGateway, atLeastOnce()).deleteHearingResult(reportedAdjudication.reportNumber, 100L)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
@@ -22,10 +22,14 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Hearing
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.NotProceedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Outcome
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Punishment
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentSchedule
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentType
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.QuashedReason
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudication
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OicHearingType
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class OutcomeServiceTest : ReportedAdjudicationTestBase() {
@@ -367,6 +371,15 @@ class OutcomeServiceTest : ReportedAdjudicationTestBase() {
         it.outcomes.add(
           Outcome(id = 1, code = code),
         )
+        it.punishments.add(
+          Punishment(
+            type = PunishmentType.CONFINEMENT,
+            suspendedUntil = LocalDate.now(),
+            schedule = mutableListOf(
+              PunishmentSchedule(days = 10),
+            ),
+          ),
+        )
       }
 
       whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(reportedAdjudication)
@@ -383,6 +396,10 @@ class OutcomeServiceTest : ReportedAdjudicationTestBase() {
 
       assertThat(argumentCaptor.value.outcomes).isEmpty()
       assertThat(argumentCaptor.value.status).isEqualTo(ReportedAdjudicationStatus.SCHEDULED)
+
+      if (code == OutcomeCode.CHARGE_PROVED) {
+        assertThat(argumentCaptor.value.punishments).isEmpty()
+      }
 
       assertThat(response).isNotNull
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsServiceTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.ArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.atLeastOnce
@@ -27,6 +28,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Punishm
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentType
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudication
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OffenderOicSanctionRequest.Companion.mapPunishmentToSanction
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonApiGateway
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -791,6 +793,84 @@ class PunishmentsServiceTest : ReportedAdjudicationTestBase() {
       assertThat(suspended.first().punishment.type).isEqualTo(PunishmentType.REMOVAL_WING)
       assertThat(suspended.first().punishment.schedule.days).isEqualTo(10)
       assertThat(suspended.first().punishment.schedule.suspendedUntil).isEqualTo(LocalDate.now())
+    }
+  }
+
+  @Nested
+  inner class PunishmentSanctionMapper {
+
+    @EnumSource(PunishmentType::class)
+    @ParameterizedTest
+    fun ` map all non privilege punishments to sanctions - suspended`(punishmentType: PunishmentType) {
+      if (punishmentType == PunishmentType.PRIVILEGE) return
+
+      val punishment = Punishment(
+        type = punishmentType,
+        schedule = mutableListOf(
+          PunishmentSchedule(days = 10, suspendedUntil = LocalDate.now()),
+        ),
+      )
+
+      val oicSanctionRequest = punishment.mapPunishmentToSanction(10.0)
+      TODO("implement me")
+    }
+
+    @EnumSource(PunishmentType::class)
+    @ParameterizedTest
+    fun ` map all non privilege punishments to sanctions - not suspended`(punishmentType: PunishmentType) {
+      if (punishmentType == PunishmentType.PRIVILEGE) return
+
+      val punishment = Punishment(
+        type = punishmentType,
+        schedule = mutableListOf(
+          PunishmentSchedule(days = 10, startDate = LocalDate.now(), endDate = LocalDate.now()),
+        ),
+      )
+
+      val oicSanctionRequest = punishment.mapPunishmentToSanction(10.0)
+      TODO("implement me")
+    }
+
+    @EnumSource(PrivilegeType::class)
+    @ParameterizedTest
+    fun `map all privilege punishments to sanctions - suspended`(privilegeType: PrivilegeType) {
+      val punishment = Punishment(
+        type = PunishmentType.PRIVILEGE,
+        privilegeType = privilegeType,
+        schedule = mutableListOf(
+          PunishmentSchedule(days = 10, suspendedUntil = LocalDate.now()),
+        ),
+      )
+
+      val oicSanctionRequest = punishment.mapPunishmentToSanction(10.0)
+      TODO("implement me")
+    }
+
+    @EnumSource(PrivilegeType::class)
+    @ParameterizedTest
+    fun `map all privilege punishments to sanctions - not suspended`(privilegeType: PrivilegeType) {
+      val punishment = Punishment(
+        type = PunishmentType.PRIVILEGE,
+        privilegeType = privilegeType,
+        schedule = mutableListOf(
+          PunishmentSchedule(days = 10, startDate = LocalDate.now(), endDate = LocalDate.now()),
+        ),
+      )
+
+      val oicSanctionRequest = punishment.mapPunishmentToSanction(10.0)
+      TODO("implement me")
+    }
+
+    @CsvSource("PROSPECTIVE_DAYS", "ADDITIONAL_DAY")
+    @ParameterizedTest
+    fun `prospective and additional days - suspended `(punishmentType: PunishmentType) {
+      TODO()
+    }
+
+    @CsvSource("PROSPECTIVE_DAYS", "ADDITIONAL_DAY")
+    @ParameterizedTest
+    fun `prospective and additional days - not suspended `(punishmentType: PunishmentType) {
+      TODO()
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsServiceTest.kt
@@ -930,8 +930,8 @@ class PunishmentsServiceTest : ReportedAdjudicationTestBase() {
       assertThat(oicSanctionRequest.sanctionDays).isEqualTo(10)
       assertThat(oicSanctionRequest.status).isEqualTo(Status.IMMEDIATE)
       assertThat(oicSanctionRequest.oicSanctionCode).isEqualTo(OicSanctionCode.FORFEIT)
-      if (privilegeType != PrivilegeType.OTHER) assertThat(oicSanctionRequest.comment).isEqualTo("Loss of $privilegeType")
-      if (privilegeType == PrivilegeType.OTHER) assertThat(oicSanctionRequest.comment).isEqualTo("Loss of nintendo switch")
+      if (privilegeType != PrivilegeType.OTHER) assertThat(oicSanctionRequest.commentText).isEqualTo("Loss of $privilegeType")
+      if (privilegeType == PrivilegeType.OTHER) assertThat(oicSanctionRequest.commentText).isEqualTo("Loss of nintendo switch")
     }
 
     @CsvSource("PROSPECTIVE_DAYS", "ADDITIONAL_DAYS")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsServiceTest.kt
@@ -861,13 +861,13 @@ class PunishmentsServiceTest : ReportedAdjudicationTestBase() {
       TODO("implement me")
     }
 
-    @CsvSource("PROSPECTIVE_DAYS", "ADDITIONAL_DAY")
+    @CsvSource("PROSPECTIVE_DAYS", "ADDITIONAL_DAYS")
     @ParameterizedTest
     fun `prospective and additional days - suspended `(punishmentType: PunishmentType) {
       TODO()
     }
 
-    @CsvSource("PROSPECTIVE_DAYS", "ADDITIONAL_DAY")
+    @CsvSource("PROSPECTIVE_DAYS", "ADDITIONAL_DAYS")
     @ParameterizedTest
     fun `prospective and additional days - not suspended `(punishmentType: PunishmentType) {
       TODO()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsServiceTest.kt
@@ -29,7 +29,9 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Punishm
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudication
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OffenderOicSanctionRequest.Companion.mapPunishmentToSanction
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OicSanctionCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.PrisonApiGateway
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.Status
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -272,6 +274,7 @@ class PunishmentsServiceTest : ReportedAdjudicationTestBase() {
             Punishment(
               id = 1,
               type = PunishmentType.PRIVILEGE,
+              privilegeType = PrivilegeType.CANTEEN,
               schedule = mutableListOf(
                 PunishmentSchedule(days = 10),
               ),
@@ -812,7 +815,6 @@ class PunishmentsServiceTest : ReportedAdjudicationTestBase() {
       )
 
       val oicSanctionRequest = punishment.mapPunishmentToSanction(10.0)
-      TODO("implement me")
     }
 
     @EnumSource(PunishmentType::class)
@@ -828,7 +830,21 @@ class PunishmentsServiceTest : ReportedAdjudicationTestBase() {
       )
 
       val oicSanctionRequest = punishment.mapPunishmentToSanction(10.0)
-      TODO("implement me")
+
+      assertThat(oicSanctionRequest.compensationAmount).isEqualTo(10.0)
+      assertThat(oicSanctionRequest.effectiveDate).isEqualTo(LocalDate.now())
+      assertThat(oicSanctionRequest.sanctionDays).isEqualTo(10)
+      assertThat(oicSanctionRequest.status).isEqualTo(Status.AS_AWARDED) // TODO confirm with nomis / John
+
+      when (punishmentType) {
+        PunishmentType.EARNINGS -> assertThat(oicSanctionRequest.oicSanctionCode).isEqualTo(OicSanctionCode.STOP_PCT)
+        PunishmentType.CONFINEMENT -> assertThat(oicSanctionRequest.oicSanctionCode).isEqualTo(OicSanctionCode.CC)
+        PunishmentType.REMOVAL_ACTIVITY -> assertThat(oicSanctionRequest.oicSanctionCode).isEqualTo(OicSanctionCode.REMACT)
+        PunishmentType.EXCLUSION_WORK -> assertThat(oicSanctionRequest.oicSanctionCode).isEqualTo(null)
+        PunishmentType.EXTRA_WORK -> assertThat(oicSanctionRequest.oicSanctionCode).isEqualTo(OicSanctionCode.EXTRA_WORK)
+        PunishmentType.REMOVAL_WING -> assertThat(oicSanctionRequest.oicSanctionCode).isEqualTo(OicSanctionCode.REMWIN)
+        else -> {}
+      }
     }
 
     @EnumSource(PrivilegeType::class)
@@ -843,7 +859,6 @@ class PunishmentsServiceTest : ReportedAdjudicationTestBase() {
       )
 
       val oicSanctionRequest = punishment.mapPunishmentToSanction(10.0)
-      TODO("implement me")
     }
 
     @EnumSource(PrivilegeType::class)
@@ -858,7 +873,20 @@ class PunishmentsServiceTest : ReportedAdjudicationTestBase() {
       )
 
       val oicSanctionRequest = punishment.mapPunishmentToSanction(10.0)
-      TODO("implement me")
+
+      assertThat(oicSanctionRequest.compensationAmount).isEqualTo(10.0)
+      assertThat(oicSanctionRequest.effectiveDate).isEqualTo(LocalDate.now())
+      assertThat(oicSanctionRequest.sanctionDays).isEqualTo(10)
+      assertThat(oicSanctionRequest.status).isEqualTo(Status.AS_AWARDED) // TODO confirm with nomis / John
+
+      when (privilegeType) {
+        PrivilegeType.CANTEEN -> assertThat(oicSanctionRequest.oicSanctionCode).isEqualTo(OicSanctionCode.CANTEEN)
+        PrivilegeType.FACILITIES -> assertThat(oicSanctionRequest.oicSanctionCode).isEqualTo(null)
+        PrivilegeType.MONEY -> assertThat(oicSanctionRequest.oicSanctionCode).isEqualTo(null)
+        PrivilegeType.TV -> assertThat(oicSanctionRequest.oicSanctionCode).isEqualTo(null)
+        PrivilegeType.ASSOCIATION -> assertThat(oicSanctionRequest.oicSanctionCode).isEqualTo(OicSanctionCode.ASSO)
+        PrivilegeType.OTHER -> assertThat(oicSanctionRequest.oicSanctionCode).isEqualTo(OicSanctionCode.OTHER)
+      }
     }
 
     @CsvSource("PROSPECTIVE_DAYS", "ADDITIONAL_DAYS")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
@@ -23,6 +23,9 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Hearing
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeCode
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Outcome
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Punishment
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentSchedule
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentType
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudication
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedOffence
@@ -46,6 +49,33 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
 
   @Nested
   inner class ReportedAdjudicationDetails {
+
+    @Test
+    fun `filter out caution and damages owed from dto if present in punishments `() {
+      whenever(reportedAdjudicationRepository.findByReportNumber(1)).thenReturn(
+        entityBuilder.reportedAdjudication().also {
+          it.createDateTime = LocalDateTime.now()
+          it.createdByUserId = ""
+          it.punishments.add(
+            Punishment(
+              type = PunishmentType.DAMAGES_OWED,
+              schedule = mutableListOf(
+                PunishmentSchedule(days = 0),
+              ),
+            ),
+          )
+          it.punishments.add(
+            Punishment(
+              type = PunishmentType.CAUTION,
+              schedule = mutableListOf(
+                PunishmentSchedule(days = 0),
+              ),
+            ),
+          )
+        },
+      )
+      assertThat(reportedAdjudicationService.getReportedAdjudicationDetails(1L).punishments).isEmpty()
+    }
 
     @Test
     fun `adjudication is not part of active case load throws exception `() {


### PR DESCRIPTION
integration of nomis sanctions, and refactoring caution and damages owed into punishments.  Note front end will still be presented the data as part of the outcome DTO to avoid extensive re-write of front end.

This PR is currently only draft as can not be merged until prison api is available to be called