### PR TITLE
NN-5187

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/ReportedAdjudicationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/ReportedAdjudicationDto.kt
@@ -74,8 +74,8 @@ data class ReportedAdjudicationDto(
   val outcomeEnteredInNomis: Boolean = false,
   @Schema(description = "optional override agency id")
   val overrideAgencyId: String?,
-  @Schema(description = "readonly flag to indicate if an ALO can carry out actions against a transferable adjudication")
-  val readonly: Boolean = false,
+  @Schema(description = "optional readonly flag to indicate if an ALO can carry out actions against a transferable adjudication, null if not transferable")
+  val transferableReadonly: Boolean? = null,
 )
 
 @Schema(description = "Details of an offence")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/ReportedAdjudicationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/ReportedAdjudicationDto.kt
@@ -146,6 +146,8 @@ data class HearingDto(
   val oicHearingType: OicHearingType,
   @Schema(description = "hearing outcome")
   val outcome: HearingOutcomeDto? = null,
+  @Schema(description = "agency id of hearing")
+  val agencyId: String,
 )
 
 @Schema(description = "hearing outcome")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/ReportedAdjudicationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/ReportedAdjudicationDto.kt
@@ -74,6 +74,8 @@ data class ReportedAdjudicationDto(
   val outcomeEnteredInNomis: Boolean = false,
   @Schema(description = "optional override agency id")
   val overrideAgencyId: String?,
+  @Schema(description = "readonly flag to indicate if an ALO can carry out actions against a transferable adjudication")
+  val readonly: Boolean = false,
 )
 
 @Schema(description = "Details of an offence")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/ReportedAdjudicationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/dtos/ReportedAdjudicationDto.kt
@@ -74,8 +74,8 @@ data class ReportedAdjudicationDto(
   val outcomeEnteredInNomis: Boolean = false,
   @Schema(description = "optional override agency id")
   val overrideAgencyId: String?,
-  @Schema(description = "optional readonly flag to indicate if an ALO can carry out actions against a transferable adjudication, null if not transferable")
-  val transferableReadonly: Boolean? = null,
+  @Schema(description = "optional actions flag to indicate if an ALO can carry out actions against a transferable adjudication, null if not transferable")
+  val transferableActionsAllowed: Boolean? = null,
 )
 
 @Schema(description = "Details of an offence")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/HearingService.kt
@@ -62,7 +62,7 @@ class HearingService(
     reportedAdjudication.let {
       it.hearings.add(
         Hearing(
-          agencyId = reportedAdjudication.agencyId,
+          agencyId = authenticationFacade.activeCaseload!!,
           reportNumber = reportedAdjudication.reportNumber,
           locationId = locationId,
           dateTimeOfHearing = dateTimeOfHearing,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -280,6 +280,7 @@ open class ReportedDtoService(
     }.sortedByDescending { it.dateTime }.toList()
 
   private fun ReportedAdjudication.getReadonlyStatus(activeCaseload: String?): Boolean? {
+    activeCaseload ?: return null
     overrideAgencyId ?: return null
     return when (this.status) {
       ReportedAdjudicationStatus.REJECTED, ReportedAdjudicationStatus.ACCEPTED -> true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -215,6 +215,7 @@ open class ReportedDtoService(
         dateTimeOfHearing = it.dateTimeOfHearing,
         oicHearingType = it.oicHearingType,
         outcome = it.hearingOutcome?.toHearingOutcomeDto(),
+        agencyId = it.agencyId,
       )
     }.sortedBy { it.dateTimeOfHearing }.toList()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -281,7 +281,6 @@ open class ReportedDtoService(
 
   private fun ReportedAdjudication.getReadonlyStatus(activeCaseload: String?): Boolean? {
     overrideAgencyId ?: return null
-    activeCaseload ?: return true
     return when (this.status) {
       ReportedAdjudicationStatus.REJECTED, ReportedAdjudicationStatus.ACCEPTED -> true
       ReportedAdjudicationStatus.AWAITING_REVIEW, ReportedAdjudicationStatus.RETURNED, ReportedAdjudicationStatus.SCHEDULED -> this.overrideAgencyId == activeCaseload

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -90,7 +90,7 @@ open class ReportedDtoService(
       punishmentComments = this.punishmentComments.toPunishmentComments(),
       outcomeEnteredInNomis = hearings.any { it.outcome?.code == HearingOutcomeCode.NOMIS },
       overrideAgencyId = this.overrideAgencyId,
-      transferableReadonly = this.getReadonlyStatus(activeCaseload),
+      transferableActionsAllowed = this.isActionable(activeCaseload),
     )
   }
 
@@ -279,14 +279,14 @@ open class ReportedDtoService(
       )
     }.sortedByDescending { it.dateTime }.toList()
 
-  private fun ReportedAdjudication.getReadonlyStatus(activeCaseload: String?): Boolean? {
+  private fun ReportedAdjudication.isActionable(activeCaseload: String?): Boolean? {
     activeCaseload ?: return null
     overrideAgencyId ?: return null
     return when (this.status) {
-      ReportedAdjudicationStatus.REJECTED, ReportedAdjudicationStatus.ACCEPTED -> true
-      ReportedAdjudicationStatus.AWAITING_REVIEW, ReportedAdjudicationStatus.RETURNED -> this.overrideAgencyId == activeCaseload
-      ReportedAdjudicationStatus.SCHEDULED -> this.getLatestHearing()?.agencyId != activeCaseload
-      else -> this.agencyId == activeCaseload
+      ReportedAdjudicationStatus.REJECTED, ReportedAdjudicationStatus.ACCEPTED -> false
+      ReportedAdjudicationStatus.AWAITING_REVIEW, ReportedAdjudicationStatus.RETURNED -> this.agencyId == activeCaseload
+      ReportedAdjudicationStatus.SCHEDULED -> this.getLatestHearing()?.agencyId == activeCaseload
+      else -> this.overrideAgencyId == activeCaseload
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Punishm
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentSchedule
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentType
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudication
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedDamage
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedEvidence
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedOffence
@@ -45,7 +46,7 @@ import java.time.LocalDateTime
 open class ReportedDtoService(
   protected val offenceCodeLookupService: OffenceCodeLookupService,
 ) {
-  protected fun ReportedAdjudication.toDto(): ReportedAdjudicationDto {
+  protected fun ReportedAdjudication.toDto(activeCaseload: String? = null): ReportedAdjudicationDto {
     val hearings = this.hearings.toHearings()
     val outcomes = this.getOutcomes().createCombinedOutcomes(this.getPunishments())
     return ReportedAdjudicationDto(
@@ -89,6 +90,7 @@ open class ReportedDtoService(
       punishmentComments = this.punishmentComments.toPunishmentComments(),
       outcomeEnteredInNomis = hearings.any { it.outcome?.code == HearingOutcomeCode.NOMIS },
       overrideAgencyId = this.overrideAgencyId,
+      transferableReadonly = this.getReadonlyStatus(activeCaseload),
     )
   }
 
@@ -277,6 +279,16 @@ open class ReportedDtoService(
       )
     }.sortedByDescending { it.dateTime }.toList()
 
+  private fun ReportedAdjudication.getReadonlyStatus(activeCaseload: String?): Boolean? {
+    overrideAgencyId ?: return null
+    activeCaseload ?: return true
+    return when (this.status) {
+      ReportedAdjudicationStatus.REJECTED, ReportedAdjudicationStatus.ACCEPTED -> true
+      ReportedAdjudicationStatus.AWAITING_REVIEW, ReportedAdjudicationStatus.RETURNED, ReportedAdjudicationStatus.SCHEDULED -> this.overrideAgencyId == activeCaseload
+      else -> this.agencyId == activeCaseload
+    }
+  }
+
   companion object {
     val outcomesToDisplayPunishments = listOf(OutcomeCode.CHARGE_PROVED, OutcomeCode.QUASHED)
     fun HearingDto.hearingHasNoAssociatedOutcome() =
@@ -311,7 +323,7 @@ open class ReportedAdjudicationBaseService(
   }
 
   protected fun saveToDto(reportedAdjudication: ReportedAdjudication): ReportedAdjudicationDto =
-    reportedAdjudicationRepository.save(reportedAdjudication).toDto()
+    reportedAdjudicationRepository.save(reportedAdjudication).toDto(authenticationFacade.activeCaseload)
 
   protected fun findByReportNumberIn(adjudicationNumbers: List<Long>) = reportedAdjudicationRepository.findByReportNumberIn(adjudicationNumbers)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -284,7 +284,8 @@ open class ReportedDtoService(
     overrideAgencyId ?: return null
     return when (this.status) {
       ReportedAdjudicationStatus.REJECTED, ReportedAdjudicationStatus.ACCEPTED -> true
-      ReportedAdjudicationStatus.AWAITING_REVIEW, ReportedAdjudicationStatus.RETURNED, ReportedAdjudicationStatus.SCHEDULED -> this.overrideAgencyId == activeCaseload
+      ReportedAdjudicationStatus.AWAITING_REVIEW, ReportedAdjudicationStatus.RETURNED -> this.overrideAgencyId == activeCaseload
+      ReportedAdjudicationStatus.SCHEDULED -> this.getLatestHearing()?.agencyId != activeCaseload
       else -> this.agencyId == activeCaseload
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -282,7 +282,7 @@ open class ReportedDtoService(
 
   private fun ReportedAdjudication.isActionable(activeCaseload: String?): Boolean? {
     activeCaseload ?: return null
-    overrideAgencyId ?: return null
+    this.overrideAgencyId ?: return null
     return when (this.status) {
       ReportedAdjudicationStatus.REJECTED, ReportedAdjudicationStatus.ACCEPTED -> false
       ReportedAdjudicationStatus.AWAITING_REVIEW, ReportedAdjudicationStatus.RETURNED -> this.agencyId == activeCaseload

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationService.kt
@@ -37,7 +37,7 @@ class ReportedAdjudicationService(
   fun getReportedAdjudicationDetails(adjudicationNumber: Long): ReportedAdjudicationDto {
     val reportedAdjudication = findByAdjudicationNumber(adjudicationNumber)
 
-    return reportedAdjudication.toDto()
+    return reportedAdjudication.toDto(authenticationFacade.activeCaseload)
   }
 
   fun lastOutcomeHasReferralOutcome(adjudicationNumber: Long): Boolean =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
@@ -1534,6 +1534,24 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
     }
   }
 
+  @Nested
+  inner class ReaonlyAdjudication {
+
+    /*
+      rules
+      1: its readonly if its awaiting review
+      2: its not readonly if its accepted
+
+     */
+
+
+    @CsvSource("1,XXX,true", "1,YYY,false", "2,YYY,false", "3,XXX,true")
+    @ParameterizedTest
+    fun `readonly test`(adjudicationNumber: Long, viewingAgency: String, expectedResult: Boolean) {
+
+    }
+  }
+
   companion object {
     private val DATE_TIME_REPORTED_ADJUDICATION_EXPIRES = LocalDateTime.of(2010, 10, 14, 10, 0)
     private val REPORTED_DATE_TIME = DATE_TIME_OF_INCIDENT.plusDays(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
@@ -1539,7 +1539,7 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
 
     @CsvSource("RETURNED", "AWAITING_REVIEW")
     @ParameterizedTest
-    fun `is editable by originating agency`(status: ReportedAdjudicationStatus) {
+    fun `is actionable for originating agency`(status: ReportedAdjudicationStatus) {
       whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
         entityBuilder.reportedAdjudication().also {
           it.status = status
@@ -1550,12 +1550,12 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
 
       val response = reportedAdjudicationService.getReportedAdjudicationDetails(1)
-      assertThat(response.transferableReadonly).isFalse
+      assertThat(response.transferableActionsAllowed).isTrue
     }
 
     @CsvSource("RETURNED", "AWAITING_REVIEW")
     @ParameterizedTest
-    fun `is readonly for override agency`(status: ReportedAdjudicationStatus) {
+    fun `is not actionable for override agency`(status: ReportedAdjudicationStatus) {
       whenever(authenticationFacade.activeCaseload).thenReturn("LEI")
       whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
         entityBuilder.reportedAdjudication().also {
@@ -1567,11 +1567,11 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
 
       val response = reportedAdjudicationService.getReportedAdjudicationDetails(1)
-      assertThat(response.transferableReadonly).isTrue
+      assertThat(response.transferableActionsAllowed).isFalse
     }
 
     @Test
-    fun `scheduled is readonly for override agency if the hearing belongs to the originating agency`() {
+    fun `scheduled is not actionable for override agency if the hearing belongs to the originating agency`() {
       whenever(authenticationFacade.activeCaseload).thenReturn("LEI")
       whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
         entityBuilder.reportedAdjudication().also {
@@ -1584,11 +1584,11 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
 
       val response = reportedAdjudicationService.getReportedAdjudicationDetails(1)
-      assertThat(response.transferableReadonly).isTrue
+      assertThat(response.transferableActionsAllowed).isFalse
     }
 
     @Test
-    fun `scheduled is editable for originating agency if the hearing belongs to the originating agency`() {
+    fun `scheduled is actionable for originating agency if the hearing belongs to the originating agency`() {
       whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
         entityBuilder.reportedAdjudication().also {
           it.status = ReportedAdjudicationStatus.SCHEDULED
@@ -1600,11 +1600,11 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
 
       val response = reportedAdjudicationService.getReportedAdjudicationDetails(1)
-      assertThat(response.transferableReadonly).isFalse
+      assertThat(response.transferableActionsAllowed).isTrue
     }
 
     @Test
-    fun `scheduled is editable for override agency if the hearing belongs to the override agency`() {
+    fun `scheduled is actionable for override agency if the hearing belongs to the override agency`() {
       whenever(authenticationFacade.activeCaseload).thenReturn("LEI")
       whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
         entityBuilder.reportedAdjudication().also {
@@ -1617,11 +1617,11 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
 
       val response = reportedAdjudicationService.getReportedAdjudicationDetails(1)
-      assertThat(response.transferableReadonly).isFalse
+      assertThat(response.transferableActionsAllowed).isTrue
     }
 
     @Test
-    fun `scheduled is readonly for originating agency if the hearing belongs to the override agency`() {
+    fun `scheduled is not actionable for originating agency if the hearing belongs to the override agency`() {
       whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
         entityBuilder.reportedAdjudication().also {
           it.status = ReportedAdjudicationStatus.SCHEDULED
@@ -1633,12 +1633,12 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
 
       val response = reportedAdjudicationService.getReportedAdjudicationDetails(1)
-      assertThat(response.transferableReadonly).isTrue
+      assertThat(response.transferableActionsAllowed).isFalse
     }
 
     @CsvSource("CHARGE_PROVED", "QUASHED", "REFER_POLICE", "REFER_INAD", "NOT_PROCEED", "PROSECUTION", "DISMISSED", "ADJOURNED", "UNSCHEDULED")
     @ParameterizedTest
-    fun `for other states it is always readonly for originating agency`(status: ReportedAdjudicationStatus) {
+    fun `for other states it is always not actionable for originating agency`(status: ReportedAdjudicationStatus) {
       whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
         entityBuilder.reportedAdjudication().also {
           it.status = status
@@ -1650,12 +1650,12 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
 
       val response = reportedAdjudicationService.getReportedAdjudicationDetails(1)
-      assertThat(response.transferableReadonly).isTrue
+      assertThat(response.transferableActionsAllowed).isFalse
     }
 
     @CsvSource("CHARGE_PROVED", "QUASHED", "REFER_POLICE", "REFER_INAD", "NOT_PROCEED", "PROSECUTION", "DISMISSED", "ADJOURNED", "UNSCHEDULED")
     @ParameterizedTest
-    fun `for other states it is always editable for override agency`(status: ReportedAdjudicationStatus) {
+    fun `for other states it is always actionable for override agency`(status: ReportedAdjudicationStatus) {
       whenever(authenticationFacade.activeCaseload).thenReturn("LEI")
       whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
         entityBuilder.reportedAdjudication().also {
@@ -1667,12 +1667,12 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
 
       val response = reportedAdjudicationService.getReportedAdjudicationDetails(1)
-      assertThat(response.transferableReadonly).isFalse
+      assertThat(response.transferableActionsAllowed).isTrue
     }
 
     @EnumSource(ReportedAdjudicationStatus::class)
     @ParameterizedTest
-    fun `report is not transferable and readonly flag should be null `(status: ReportedAdjudicationStatus) {
+    fun `report is not transferable and actionable flag should be null `(status: ReportedAdjudicationStatus) {
       whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
         entityBuilder.reportedAdjudication().also {
           it.status = status
@@ -1682,12 +1682,12 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
 
       val response = reportedAdjudicationService.getReportedAdjudicationDetails(1)
-      assertThat(response.transferableReadonly).isNull()
+      assertThat(response.transferableActionsAllowed).isNull()
     }
 
     @CsvSource("ACCEPTED", "REJECTED")
     @ParameterizedTest
-    fun `always returns readonly is true`(status: ReportedAdjudicationStatus) {
+    fun `always returns not actionable`(status: ReportedAdjudicationStatus) {
       whenever(reportedAdjudicationRepository.findByReportNumber(any())).thenReturn(
         entityBuilder.reportedAdjudication().also {
           it.status = status
@@ -1698,7 +1698,7 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       )
 
       val response = reportedAdjudicationService.getReportedAdjudicationDetails(1)
-      assertThat(response.transferableReadonly).isTrue
+      assertThat(response.transferableActionsAllowed).isFalse
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
@@ -6,6 +6,7 @@ import jakarta.validation.ValidationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -1538,18 +1539,16 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
   inner class ReaonlyAdjudication {
 
     /*
-      rules
-      1: its readonly if its awaiting review
-      2: its not readonly if its accepted
+       rules/
 
+       reported: awaiting review / returned - edit > originating agency
+       reported: unscheduled > edit override agency
+       reported: scheduled > edit for agency that owns hearing
      */
 
 
-    @CsvSource("1,XXX,true", "1,YYY,false", "2,YYY,false", "3,XXX,true")
-    @ParameterizedTest
-    fun `readonly test`(adjudicationNumber: Long, viewingAgency: String, expectedResult: Boolean) {
+    //specifc tests are better.
 
-    }
   }
 
   companion object {


### PR DESCRIPTION
optional transferable actionable flag for ALO UI controls to indicate the current user can, or can not action the report

When creating a hearing, the agency id must now be set from the activeCaseload