### PR TITLE
NN-5252 reset override if transferring back

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/TransferService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/TransferService.kt
@@ -19,9 +19,14 @@ class TransferService(
       reportedAdjudicationRepository.findByPrisonerNumberAndStatusIn(
         prisonerNumber = prisonerNumber,
         statuses = transferableStatuses,
-      ).filter { it.originatingAgencyId != agencyId }.forEach {
+      ).forEach {
         log.info("transferring report ${it.reportNumber} from ${it.originatingAgencyId} to $agencyId")
-        it.overrideAgencyId = agencyId
+        if (it.originatingAgencyId != agencyId) {
+          it.overrideAgencyId = agencyId
+        } else {
+          // we remove the lock, and the originating agency has full control again
+          it.overrideAgencyId = null
+        }
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/TransferServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/TransferServiceTest.kt
@@ -38,6 +38,22 @@ class TransferServiceTest : ReportedAdjudicationTestBase() {
     verify(reportedAdjudicationRepository, never()).findByPrisonerNumberAndStatusIn(any(), any())
   }
 
+  @Test
+  fun `when prisoner is transferred back to originating agency override is removed`() {
+    val reportedAdjudication = entityBuilder.reportedAdjudication().also {
+      it.originatingAgencyId = "MDI"
+      it.overrideAgencyId = "LEI"
+    }
+
+    whenever(reportedAdjudicationRepository.findByPrisonerNumberAndStatusIn("AA1234A", transferableStatuses)).thenReturn(
+      listOf(reportedAdjudication),
+    )
+
+    transferService.processTransferEvent(prisonerNumber = "AA1234A", agencyId = "MDI")
+
+    assertThat(reportedAdjudication.overrideAgencyId).isNull()
+  }
+
   override fun `throws an entity not found if the reported adjudication for the supplied id does not exists`() {
     // not applicable
   }


### PR DESCRIPTION
in the instance a report is created for a prisoner outside of the estate, only for them to be transferred back, the override agency id should be removed.
