### PR TITLE
NN-5256 transfer improvements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
@@ -26,6 +26,7 @@ data class ReportedAdjudication(
   var reportNumber: Long,
   var originatingAgencyId: String,
   var overrideAgencyId: String? = null,
+  var lastModifiedAgencyId: String? = null,
   var locationId: Long,
   var dateTimeOfIncident: LocalDateTime,
   var dateTimeOfDiscovery: LocalDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepository.kt
@@ -30,22 +30,8 @@ interface ReportedAdjudicationRepository : CrudRepository<ReportedAdjudication, 
   ): Page<ReportedAdjudication>
 
   @Query(
-    value = "select * from reported_adjudications ra " +
-      "where ra.date_time_of_discovery > :startDate and ra.date_time_of_discovery <= :endDate " +
-      "and ra.status in :statuses " +
-      "and (" +
-      "ra.originating_agency_id = :agencyId " +
-      "or ra.override_agency_id = :agencyId and ra.status not in :transferIgnoreStatuses and coalesce(ra.last_modified_agency_id,ra.originating_agency_id) != :agencyId " +
-      "or ra.override_agency_id = :agencyId and coalesce(ra.last_modified_agency_id,ra.originating_agency_id) = :agencyId" +
-      ")",
-    countQuery = "select count(1) from reported_adjudications ra " +
-      "where ra.date_time_of_discovery > :startDate and ra.date_time_of_discovery <= :endDate " +
-      "and ra.status in :statuses " +
-      "and (" +
-      "ra.originating_agency_id = :agencyId " +
-      "or ra.override_agency_id = :agencyId and ra.status not in :transferIgnoreStatuses and coalesce(ra.last_modified_agency_id,ra.originating_agency_id) != :agencyId " +
-      "or ra.override_agency_id = :agencyId and coalesce(ra.last_modified_agency_id,ra.originating_agency_id) = :agencyId" +
-      ")",
+    value = "select * from reported_adjudications ra $allReportsWhereClause",
+    countQuery = "select count(1) from reported_adjudications ra $allReportsWhereClause",
     nativeQuery = true,
   )
   fun findAllReportsByAgency(
@@ -104,4 +90,14 @@ interface ReportedAdjudicationRepository : CrudRepository<ReportedAdjudication, 
     @Param("overrideAgencyId") overrideAgencyId: String,
     @Param("statuses") statuses: List<String>,
   ): Long
+
+  companion object {
+    const val allReportsWhereClause = "where ra.date_time_of_discovery > :startDate and ra.date_time_of_discovery <= :endDate " +
+      "and ra.status in :statuses " +
+      "and (" +
+      "ra.originating_agency_id = :agencyId " +
+      "or ra.override_agency_id = :agencyId and ra.status not in :transferIgnoreStatuses and coalesce(ra.last_modified_agency_id,ra.originating_agency_id) != :agencyId " +
+      "or ra.override_agency_id = :agencyId and coalesce(ra.last_modified_agency_id,ra.originating_agency_id) = :agencyId" +
+      ")"
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -326,7 +326,11 @@ open class ReportedAdjudicationBaseService(
   }
 
   protected fun saveToDto(reportedAdjudication: ReportedAdjudication): ReportedAdjudicationDto =
-    reportedAdjudicationRepository.save(reportedAdjudication).toDto(authenticationFacade.activeCaseload)
+    reportedAdjudicationRepository.save(
+      reportedAdjudication.also {
+        it.lastModifiedAgencyId = authenticationFacade.activeCaseload
+      },
+    ).toDto(authenticationFacade.activeCaseload)
 
   protected fun findByReportNumberIn(adjudicationNumbers: List<Long>) = reportedAdjudicationRepository.findByReportNumberIn(adjudicationNumbers)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportsService.kt
@@ -113,9 +113,9 @@ class ReportsService(
       status = ReportedAdjudicationStatus.AWAITING_REVIEW,
     )
 
-    val transferReviewTotal = reportedAdjudicationRepository.countByOverrideAgencyIdAndStatusIn(
+    val transferReviewTotal = reportedAdjudicationRepository.countTransfers(
       overrideAgencyId = agencyId,
-      statuses = transferReviewStatuses,
+      statuses = transferReviewStatuses.map { it.name },
     )
 
     return AgencyReportCountsDto(

--- a/src/main/resources/db/migration/V67__reported_adjudication_last_active_caseload.sql
+++ b/src/main/resources/db/migration/V67__reported_adjudication_last_active_caseload.sql
@@ -1,0 +1,1 @@
+ALTER TABLE reported_adjudications ADD COLUMN last_modified_agency_id varchar(6);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepositoryTest.kt
@@ -88,6 +88,18 @@ class ReportedAdjudicationRepositoryTest {
     )
     entityManager.persistAndFlush(
       entityBuilder.reportedAdjudication(
+        reportNumber = 123666L,
+        dateTime = dateTimeOfIncident.plusHours(1),
+        agencyId = "TJW",
+        hearingId = null,
+      ).also {
+        it.overrideAgencyId = "LEI"
+        it.status = ReportedAdjudicationStatus.ADJOURNED
+        it.lastModifiedAgencyId = "LEI"
+      },
+    )
+    entityManager.persistAndFlush(
+      entityBuilder.reportedAdjudication(
         reportNumber = 9999L,
         dateTime = dateTimeOfIncident.plusHours(1),
         agencyId = "TJW",
@@ -132,6 +144,20 @@ class ReportedAdjudicationRepositoryTest {
         it.dateTimeOfIssue = LocalDateTime.now()
         it.dateTimeOfFirstHearing = LocalDateTime.now()
         it.overrideAgencyId = "MDI"
+      },
+    )
+    entityManager.persistAndFlush(
+      entityBuilder.reportedAdjudication(
+        reportNumber = 199977L,
+        dateTime = dateTimeOfIncident.plusHours(1),
+        agencyId = "LEI",
+        hearingId = null,
+      ).also {
+        it.status = ReportedAdjudicationStatus.UNSCHEDULED
+        it.dateTimeOfIssue = LocalDateTime.now()
+        it.dateTimeOfFirstHearing = LocalDateTime.now()
+        it.overrideAgencyId = "MDI"
+        it.lastModifiedAgencyId = "MDI"
       },
     )
   }
@@ -336,11 +362,12 @@ class ReportedAdjudicationRepositoryTest {
       Pageable.ofSize(10),
     )
 
-    assertThat(foundAdjudications.content).hasSize(2)
+    assertThat(foundAdjudications.content).hasSize(3)
       .extracting("reportNumber")
       .contains(
         1236L,
         12366L,
+        123666L,
       )
   }
 
@@ -507,7 +534,7 @@ class ReportedAdjudicationRepositoryTest {
   fun `hearing without outcome test`() {
     val hearings = hearingRepository.findByHearingOutcomeIsNull()
 
-    assertThat(hearings.size).isEqualTo(8)
+    assertThat(hearings.size).isEqualTo(10)
   }
 
   @Test
@@ -528,20 +555,20 @@ class ReportedAdjudicationRepositoryTest {
       statuses = listOf(ReportedAdjudicationStatus.UNSCHEDULED),
     )
 
-    assertThat(adjudications.size).isEqualTo(3)
+    assertThat(adjudications.size).isEqualTo(4)
   }
 
   @Test
   fun `count by agency and status `() {
     assertThat(
       reportedAdjudicationRepository.countByOriginatingAgencyIdAndStatus("LEI", ReportedAdjudicationStatus.UNSCHEDULED),
-    ).isEqualTo(2)
+    ).isEqualTo(3)
   }
 
   @Test
   fun `count by override agency id and status`() {
     assertThat(
-      reportedAdjudicationRepository.countByOverrideAgencyIdAndStatusIn("MDI", listOf(ReportedAdjudicationStatus.UNSCHEDULED)),
+      reportedAdjudicationRepository.countTransfers("MDI", listOf(ReportedAdjudicationStatus.UNSCHEDULED).map { it.name }),
     ).isEqualTo(1)
   }
 
@@ -555,6 +582,6 @@ class ReportedAdjudicationRepositoryTest {
       Pageable.ofSize(10),
     )
 
-    assertThat(page.content.size).isEqualTo(1)
+    assertThat(page.content.size).isEqualTo(2)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationServiceTest.kt
@@ -353,6 +353,7 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
         entityBuilder.reportedAdjudication(dateTime = DATE_TIME_OF_INCIDENT).also {
           it.status = to
           it.reviewUserId = if (to == ReportedAdjudicationStatus.AWAITING_REVIEW) null else "ITAG_USER"
+          it.lastModifiedAgencyId = it.originatingAgencyId
         },
       )
       if (updatesNomis) {
@@ -388,6 +389,7 @@ class ReportedAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       returnedReportedAdjudication.reviewUserId = "ITAG_USER"
       returnedReportedAdjudication.createdByUserId = "A_USER"
       returnedReportedAdjudication.createDateTime = REPORTED_DATE_TIME
+      returnedReportedAdjudication.lastModifiedAgencyId = returnedReportedAdjudication.originatingAgencyId
       whenever(reportedAdjudicationRepository.save(any())).thenReturn(
         returnedReportedAdjudication,
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportsServiceTest.kt
@@ -292,7 +292,7 @@ class ReportsServiceTest : ReportedAdjudicationTestBase() {
     @Test
     fun `get reports count for agency`() {
       whenever(reportedAdjudicationRepository.countByOriginatingAgencyIdAndStatus("MDI", ReportedAdjudicationStatus.AWAITING_REVIEW)).thenReturn(2)
-      whenever(reportedAdjudicationRepository.countByOverrideAgencyIdAndStatusIn("MDI", transferReviewStatuses)).thenReturn(1)
+      whenever(reportedAdjudicationRepository.countTransfers("MDI", transferReviewStatuses.map { it.name })).thenReturn(1)
 
       val result = reportsService.getReportCounts()
 


### PR DESCRIPTION
improvements to how transfers are counted, and all reports filtered, based on which agency last modified the adjudication.

This is to stop moving valid transferred reports back to the transfers only view, when the override agency has carried out the action, ie refer to police, or adjourn