### PR TITLE
NN-5283 additional days filter on suspended punishments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/PunishmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/PunishmentsController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.config.ErrorResponse
@@ -120,7 +121,8 @@ class PunishmentsController(
   @ResponseStatus(HttpStatus.OK)
   fun getSuspendedPunishments(
     @PathVariable(name = "prisonerNumber") prisonerNumber: String,
-  ): List<SuspendedPunishmentDto> = punishmentsService.getSuspendedPunishments(prisonerNumber = prisonerNumber)
+    @RequestParam(name = "reportNumber", required = false) reportNumber: Long? = null,
+  ): List<SuspendedPunishmentDto> = punishmentsService.getSuspendedPunishments(prisonerNumber = prisonerNumber, reportNumber = reportNumber)
 
   @Operation(
     summary = "create punishment comment",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisHearingDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/gateways/NomisHearingDto.kt
@@ -16,6 +16,10 @@ enum class OicHearingType {
       false -> if (listOf(GOV_YOI, INAD_YOI).contains(this)) throw IllegalStateException("oic hearing type is not applicable for rule set")
     }
   }
+
+  companion object {
+    fun inadTypes() = listOf(INAD_ADULT, INAD_YOI)
+  }
 }
 
 data class OicHearingRequest(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
@@ -165,10 +165,14 @@ class PunishmentsService(
 
   fun getSuspendedPunishments(prisonerNumber: String, reportNumber: Long? = null): List<SuspendedPunishmentDto> {
     val reportsWithSuspendedPunishments = getReportsWithSuspendedPunishments(prisonerNumber = prisonerNumber)
+    var includeAdditionalDays: Boolean? = null
+    reportNumber?.let {
+      includeAdditionalDays = includeAdditionalDays(it)
+    }
 
     return reportsWithSuspendedPunishments.map {
       it.getPunishments().suspendedPunishmentsToActivate()
-        .filter { punishment -> reportNumber == null || punishment.type.includeInSuspendedPunishments(includeAdditionalDays(reportNumber)) }
+        .filter { punishment -> reportNumber == null || punishment.type.includeInSuspendedPunishments(includeAdditionalDays!!) }
         .map { punishment ->
           val schedule = punishment.schedule.latestSchedule()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
@@ -163,25 +163,27 @@ class PunishmentsService(
     return saveToDto(reportedAdjudication)
   }
 
-  fun getSuspendedPunishments(prisonerNumber: String): List<SuspendedPunishmentDto> {
+  fun getSuspendedPunishments(prisonerNumber: String, reportNumber: Long? = null): List<SuspendedPunishmentDto> {
     val reportsWithSuspendedPunishments = getReportsWithSuspendedPunishments(prisonerNumber = prisonerNumber)
 
     return reportsWithSuspendedPunishments.map {
-      it.getPunishments().suspendedPunishmentsToActivate().map { p ->
-        val schedule = p.schedule.latestSchedule()
+      it.getPunishments().suspendedPunishmentsToActivate()
+        .filter { punishment -> reportNumber == null || punishment.type.includeInSuspendedPunishments(includeAdditionalDays(reportNumber)) }
+        .map { punishment ->
+          val schedule = punishment.schedule.latestSchedule()
 
-        SuspendedPunishmentDto(
-          reportNumber = it.reportNumber,
-          punishment = PunishmentDto(
-            id = p.id,
-            type = p.type,
-            privilegeType = p.privilegeType,
-            otherPrivilege = p.otherPrivilege,
-            stoppagePercentage = p.stoppagePercentage,
-            schedule = PunishmentScheduleDto(days = schedule.days, suspendedUntil = schedule.suspendedUntil),
-          ),
-        )
-      }
+          SuspendedPunishmentDto(
+            reportNumber = it.reportNumber,
+            punishment = PunishmentDto(
+              id = punishment.id,
+              type = punishment.type,
+              privilegeType = punishment.privilegeType,
+              otherPrivilege = punishment.otherPrivilege,
+              stoppagePercentage = punishment.stoppagePercentage,
+              schedule = PunishmentScheduleDto(days = schedule.days, suspendedUntil = schedule.suspendedUntil),
+            ),
+          )
+        }
     }.flatten()
   }
 
@@ -228,6 +230,11 @@ class PunishmentsService(
     reportedAdjudication.punishmentComments.remove(punishmentComment)
 
     return saveToDto(reportedAdjudication)
+  }
+
+  private fun includeAdditionalDays(reportNumber: Long): Boolean {
+    val reportedAdjudication = findByAdjudicationNumber(reportNumber)
+    return OicHearingType.inadTypes().contains(reportedAdjudication.getLatestHearing()?.oicHearingType)
   }
 
   private fun handleDamagesOwedChange(reportedAdjudication: ReportedAdjudication, amount: Double?) {
@@ -435,7 +442,7 @@ class PunishmentsService(
           }
         }
         PunishmentType.EARNINGS -> this.stoppagePercentage ?: throw ValidationException("stoppage percentage missing for type EARNINGS")
-        PunishmentType.PROSPECTIVE_DAYS, PunishmentType.ADDITIONAL_DAYS -> if (latestHearing?.oicHearingType != OicHearingType.INAD_ADULT) throw ValidationException("Punishment ${this.type} is invalid as the punishment decision was not awarded by an independent adjudicator")
+        PunishmentType.PROSPECTIVE_DAYS, PunishmentType.ADDITIONAL_DAYS -> if (!OicHearingType.inadTypes().contains(latestHearing?.oicHearingType)) throw ValidationException("Punishment ${this.type} is invalid as the punishment decision was not awarded by an independent adjudicator")
         else -> {}
       }
       when (this.type) {
@@ -460,6 +467,14 @@ class PunishmentsService(
     fun String.validatePunishmentCommentAction(username: String) {
       if (this != username) {
         throw ForbiddenException("Only $this can carry out action on punishment comment. attempt by $username")
+      }
+    }
+
+    fun PunishmentType.includeInSuspendedPunishments(includeAdditionalDays: Boolean): Boolean {
+      return if (!listOf(PunishmentType.ADDITIONAL_DAYS, PunishmentType.PROSPECTIVE_DAYS).contains(this)) {
+        true
+      } else {
+        includeAdditionalDays
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/PunishmentsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/PunishmentsControllerTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -180,6 +181,7 @@ class PunishmentsControllerTest : TestControllerBase() {
       whenever(
         punishmentsService.getSuspendedPunishments(
           any(),
+          anyOrNull(),
         ),
       ).thenReturn(SUSPENDED_PUNISHMENTS_DTO)
     }


### PR DESCRIPTION
Optional request param to apply filter. - as soon as front end implemented and in prod, can delete all the logic around reportNumber being null

Note bug fix for punishment validation, need to include INAD_YOI as well