### PR TITLE
NN-5481 correct nomis code

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/OffenceCodes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/OffenceCodes.kt
@@ -76,7 +76,7 @@ enum class OffenceCodes(val paragraph: String, private val withOthers: String? =
   YOI_55_21C(paragraph = "21", withOthers = "55:29AF", uniqueOffenceCodes = listOf(19002), paragraphDescription = Descriptions.YOI_21),
   YOI_55_21A(paragraph = "21", withOthers = "55:29AD", uniqueOffenceCodes = listOf(19003), paragraphDescription = Descriptions.YOI_21),
   YOI_55_23(paragraph = "23", uniqueOffenceCodes = listOf(20001), paragraphDescription = Descriptions.YOI_23_ADULT_20A),
-  YOI_55_20(paragraph = "22", withOthers = "55:29AC", uniqueOffenceCodes = listOf(20002), paragraphDescription = Descriptions.YOI_22_ADULT_20),
+  YOI_55_22(paragraph = "22", withOthers = "55:29AC", uniqueOffenceCodes = listOf(20002), paragraphDescription = Descriptions.YOI_22_ADULT_20),
   YOI_55_25(paragraph = "25", withOthers = "55:29W", uniqueOffenceCodes = listOf(22001), paragraphDescription = Descriptions.YOI_25_ADULT_22),
   YOI_55_26(paragraph = "26", withOthers = "55:29AI", uniqueOffenceCodes = listOf(23101), paragraphDescription = Descriptions.YOI_26_ADULT_23),
   YOI_55_3A(paragraph = "3", withOthers = "55:29K", uniqueOffenceCodes = listOf(2001, 2021), paragraphDescription = Descriptions.YOI_3_ADULT_2),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/OffenceCodeParagraphDescriptionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/OffenceCodeParagraphDescriptionsTest.kt
@@ -39,7 +39,7 @@ class OffenceCodeParagraphDescriptionsTest {
     "55:21C,YOI_21",
     "55:21A,YOI_21",
     "55:23,YOI_23_ADULT_20A",
-    "55:20,YOI_22_ADULT_20",
+    "55:22,YOI_22_ADULT_20",
     "55:25,YOI_25_ADULT_22",
     "55:26,YOI_26_ADULT_23",
     "55:3A,YOI_3_ADULT_2",


### PR DESCRIPTION
caused by https://github.com/ministryofjustice/hmpps-manage-adjudications-api/blob/0e171d13c9b9b70f1fce09fdc064c894185a76b3/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/YouthOffenceCodes.kt#L123