### PR TITLE
NN-5344 damages event

### DIFF
--- a/applicationinsights.dev.json
+++ b/applicationinsights.dev.json
@@ -13,6 +13,9 @@
   "selfDiagnostics": {
     "destination": "console"
   },
+  "sampling": {
+    "percentage": 100
+  },
   "preview": {
     "sampling": {
       "overrides": [

--- a/applicationinsights.json
+++ b/applicationinsights.json
@@ -15,7 +15,6 @@
   },
   "preview": {
     "sampling": {
-      "percentage": 100,
       "overrides": [
         {
           "attributes": [

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -9,7 +9,7 @@ generic-service:
 
   env:
     JAVA_OPTS: "-Xmx1G"
-    APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
+    APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     OAUTH_ENDPOINT_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json
     PRISON_API_ENDPOINT_URL: https://api-preprod.prison.service.justice.gov.uk

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/DamagesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/DamagesController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.draft.DamagesRequest
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.AdjudicationDomainEventType
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.DamagesService
 
 @PreAuthorize("hasRole('VIEW_ADJUDICATIONS') and hasAuthority('SCOPE_write')")
@@ -27,12 +28,14 @@ class DamagesController(
     @PathVariable(name = "chargeNumber") chargeNumber: String,
     @RequestBody @Valid
     damagesRequest: DamagesRequest,
-  ): ReportedAdjudicationResponse {
-    val reportedAdjudication = damagesService.updateDamages(
-      chargeNumber,
-      damagesRequest.damages,
+  ): ReportedAdjudicationResponse =
+    eventPublishWrapper(
+      event = AdjudicationDomainEventType.DAMAGES_UPDATED,
+      controllerAction = {
+        damagesService.updateDamages(
+          chargeNumber,
+          damagesRequest.damages,
+        )
+      },
     )
-
-    return ReportedAdjudicationResponse(reportedAdjudication)
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/AuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/AuditService.kt
@@ -66,4 +66,5 @@ data class AuditEvent(
 
 enum class AuditType {
   ADJUDICATION_CREATED,
+  DAMAGES_UPDATED,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/SnsService.kt
@@ -93,6 +93,7 @@ data class HMPPSDomainEvent(
 
 enum class AdjudicationDomainEventType(val value: String, val description: String, val auditType: AuditType) {
   ADJUDICATION_CREATED("adjudication.report.created", "An adjudication has been created: ", AuditType.ADJUDICATION_CREATED),
+  DAMAGES_UPDATED("adjudication.damages.updated", "Adjudication damages updated: ", AuditType.DAMAGES_UPDATED),
 }
 
 fun Instant.toOffsetDateFormat(): String =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/migrate/MigrateExistingRecordService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/migrate/MigrateExistingRecordService.kt
@@ -225,9 +225,8 @@ class MigrateExistingRecordService(
   companion object {
     fun Hearing.filterOutPreviousPhases(): Boolean = this.hearingOutcome?.nomisOutcome != true && this.hearingOutcome?.migrated != true
     fun List<Hearing>.hasHearingWithoutResult(): Boolean {
-      if (this.isEmpty()) return false
       val hearingsWithoutLast = this.sortedBy { it.dateTimeOfHearing }
-      hearingsWithoutLast.toMutableList().removeLast()
+      hearingsWithoutLast.toMutableList().removeLastOrNull()
 
       return hearingsWithoutLast.any { it.hearingOutcome == null }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/migrate/MigrateExistingRecordService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/migrate/MigrateExistingRecordService.kt
@@ -225,6 +225,7 @@ class MigrateExistingRecordService(
   companion object {
     fun Hearing.filterOutPreviousPhases(): Boolean = this.hearingOutcome?.nomisOutcome != true && this.hearingOutcome?.migrated != true
     fun List<Hearing>.hasHearingWithoutResult(): Boolean {
+      if (this.isEmpty()) return false
       val hearingsWithoutLast = this.sortedBy { it.dateTimeOfHearing }
       hearingsWithoutLast.toMutableList().removeLast()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/DamagesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/reported/DamagesControllerTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.kotlin.any
+import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
@@ -19,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.Test
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.draft.DamageRequestItem
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.draft.DamagesRequest
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.DamageCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.AdjudicationDomainEventType
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.DamagesService
 
 @WebMvcTest(
@@ -52,6 +54,8 @@ class DamagesControllerTest : TestControllerBase() {
       .andExpect(MockMvcResultMatchers.status().isOk)
 
     verify(damagesService).updateDamages("1", DAMAGES_REQUEST.damages)
+
+    verify(eventPublishService, atLeastOnce()).publishEvent(AdjudicationDomainEventType.DAMAGES_UPDATED, REPORTED_ADJUDICATION_DTO)
   }
 
   private fun setDamagesRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/AmendHearingOutcomesIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/AmendHearingOutcomesIntTest.kt
@@ -27,7 +27,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing().createReferral(code = HearingOutcomeCode.REFER_POLICE)
+    initDataForOutcome().createHearing().createReferral(code = HearingOutcomeCode.REFER_POLICE)
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.REFER_POLICE.name}/v2")
@@ -55,7 +55,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
   fun `amend hearing outcome test - before - refer inad, after - refer inad`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForHearings().createHearing().createReferral(code = HearingOutcomeCode.REFER_INAD)
+    initDataForOutcome().createHearing().createReferral(code = HearingOutcomeCode.REFER_INAD)
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.REFER_INAD.name}/v2")
@@ -84,7 +84,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing().createAdjourn()
+    initDataForOutcome().createHearing().createAdjourn()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.ADJOURNED.name}/v2")
@@ -120,7 +120,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubDeleteSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing().createChargeProved()
+    initDataForOutcome().createHearing().createChargeProved()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.CHARGE_PROVED.name}/v2")
@@ -149,7 +149,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing().createNotProceed()
+    initDataForOutcome().createHearing().createNotProceed()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.NOT_PROCEED.name}/v2")
@@ -183,7 +183,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing().createDismissed()
+    initDataForOutcome().createHearing().createDismissed()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.DISMISSED.name}/v2")
@@ -226,7 +226,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubDeleteSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = if (from == ReportedAdjudicationStatus.REFER_GOV) OicHearingType.INAD_ADULT else OicHearingType.GOV_ADULT).also {
+    initDataForOutcome().createHearing(oicHearingType = if (from == ReportedAdjudicationStatus.REFER_GOV) OicHearingType.INAD_ADULT else OicHearingType.GOV_ADULT).also {
       when (from) {
         ReportedAdjudicationStatus.REFER_POLICE, ReportedAdjudicationStatus.REFER_INAD, ReportedAdjudicationStatus.REFER_GOV -> it.createReferral(HearingOutcomeCode.valueOf(from.name))
         ReportedAdjudicationStatus.DISMISSED -> it.createDismissed()
@@ -322,7 +322,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createOutcomeReferPolice().createHearing().createAdjourn()
+    initDataForOutcome().createOutcomeReferPolice().createHearing().createAdjourn()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.DISMISSED.name}/v2")
@@ -345,7 +345,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing().createReferral(HearingOutcomeCode.REFER_POLICE).createOutcomeNotProceed()
+    initDataForOutcome().createHearing().createReferral(HearingOutcomeCode.REFER_POLICE).createOutcomeNotProceed()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.REFER_POLICE.name}/v2")
@@ -368,7 +368,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubDeleteSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing().createChargeProved().createPunishments()
+    initDataForOutcome().createHearing().createChargeProved().createPunishments()
 
     amendOutcomeRequest(
       request = AmendHearingOutcomeRequest(adjudicator = "", plea = HearingOutcomePlea.GUILTY, details = ""),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/AmendHearingOutcomesIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/AmendHearingOutcomesIntTest.kt
@@ -27,7 +27,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createReferral(code = HearingOutcomeCode.REFER_POLICE)
+    initDataForUnScheduled().createHearing().createReferral(code = HearingOutcomeCode.REFER_POLICE)
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.REFER_POLICE.name}/v2")
@@ -55,7 +55,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
   fun `amend hearing outcome test - before - refer inad, after - refer inad`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing().createReferral(code = HearingOutcomeCode.REFER_INAD)
+    initDataForUnScheduled().createHearing().createReferral(code = HearingOutcomeCode.REFER_INAD)
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.REFER_INAD.name}/v2")
@@ -84,7 +84,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createAdjourn()
+    initDataForUnScheduled().createHearing().createAdjourn()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.ADJOURNED.name}/v2")
@@ -120,7 +120,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubDeleteSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createChargeProved()
+    initDataForUnScheduled().createHearing().createChargeProved()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.CHARGE_PROVED.name}/v2")
@@ -149,7 +149,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createNotProceed()
+    initDataForUnScheduled().createHearing().createNotProceed()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.NOT_PROCEED.name}/v2")
@@ -183,7 +183,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createDismissed()
+    initDataForUnScheduled().createHearing().createDismissed()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.DISMISSED.name}/v2")
@@ -226,7 +226,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubDeleteSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = if (from == ReportedAdjudicationStatus.REFER_GOV) OicHearingType.INAD_ADULT else OicHearingType.GOV_ADULT).also {
+    initDataForUnScheduled().createHearing(oicHearingType = if (from == ReportedAdjudicationStatus.REFER_GOV) OicHearingType.INAD_ADULT else OicHearingType.GOV_ADULT).also {
       when (from) {
         ReportedAdjudicationStatus.REFER_POLICE, ReportedAdjudicationStatus.REFER_INAD, ReportedAdjudicationStatus.REFER_GOV -> it.createReferral(HearingOutcomeCode.valueOf(from.name))
         ReportedAdjudicationStatus.DISMISSED -> it.createDismissed()
@@ -322,7 +322,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createOutcomeReferPolice().createHearing().createAdjourn()
+    initDataForUnScheduled().createOutcomeReferPolice().createHearing().createAdjourn()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.DISMISSED.name}/v2")
@@ -345,7 +345,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createReferral(HearingOutcomeCode.REFER_POLICE).createOutcomeNotProceed()
+    initDataForUnScheduled().createHearing().createReferral(HearingOutcomeCode.REFER_POLICE).createOutcomeNotProceed()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/${ReportedAdjudicationStatus.REFER_POLICE.name}/v2")
@@ -368,7 +368,7 @@ class AmendHearingOutcomesIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubDeleteSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createChargeProved().createPunishments()
+    initDataForUnScheduled().createHearing().createChargeProved().createPunishments()
 
     amendOutcomeRequest(
       request = AmendHearingOutcomeRequest(adjudicator = "", plea = HearingOutcomePlea.GUILTY, details = ""),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
@@ -19,7 +19,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `create a hearing `() {
-    initDataForOutcome()
+    initDataForUnScheduled()
 
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 12, 10, 0)
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
@@ -49,7 +49,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `create a hearing illegal state on hearing type `() {
-    initDataForOutcome()
+    initDataForUnScheduled()
 
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 12, 10, 0)
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
@@ -70,7 +70,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `create hearing fails on prisonApi and does not create a hearing`() {
-    initDataForOutcome()
+    initDataForUnScheduled()
 
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 12, 10, 0)
 
@@ -101,7 +101,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `amend a hearing `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 25, 10, 0)
@@ -132,7 +132,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `amend a hearing illegal state on hearing type `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 25, 10, 0)
@@ -154,7 +154,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `amend a hearing fails on prison api and does not update the hearing `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     prisonApiMockServer.stubAmendHearingFailure(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 25, 10, 0)
@@ -188,7 +188,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `delete a hearing `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
     prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
     webTestClient.delete()
@@ -205,7 +205,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `delete a hearing fails on prison api and does not delete record`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     prisonApiMockServer.stubDeleteHearingFailure(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
@@ -229,7 +229,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     webTestClient.post()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/adjourn")
@@ -265,7 +265,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `create hearing outcome for referral`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
@@ -300,7 +300,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `referral transaction is rolled back when hearing outcome succeeds and outcome creation fails`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/status")
@@ -342,7 +342,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `get all hearings`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     webTestClient.get()
       .uri("/reported-adjudications/hearings?hearingDate=${IntegrationTestData.DEFAULT_ADJUDICATION.dateTimeOfHearing!!.toLocalDate()}")
@@ -370,7 +370,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createAdjourn()
+    initDataForUnScheduled().createHearing().createAdjourn()
 
     webTestClient.delete()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/adjourn")
@@ -389,7 +389,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createAdjourn()
+    initDataForUnScheduled().createHearing().createAdjourn()
 
     webTestClient.post()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/v2")
@@ -413,7 +413,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome()
+    initDataForUnScheduled()
       .createOutcomeReferPolice()
       .createHearing(dateTimeOfHearing = LocalDateTime.now())
       .createAdjourn()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/HearingsIntTest.kt
@@ -19,7 +19,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `create a hearing `() {
-    initDataForHearings()
+    initDataForOutcome()
 
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 12, 10, 0)
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
@@ -49,7 +49,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `create a hearing illegal state on hearing type `() {
-    initDataForHearings()
+    initDataForOutcome()
 
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 12, 10, 0)
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
@@ -70,7 +70,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `create hearing fails on prisonApi and does not create a hearing`() {
-    initDataForHearings()
+    initDataForOutcome()
 
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 12, 10, 0)
 
@@ -101,7 +101,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `amend a hearing `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForHearings().createHearing()
+    initDataForOutcome().createHearing()
 
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 25, 10, 0)
@@ -132,7 +132,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `amend a hearing illegal state on hearing type `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForHearings().createHearing()
+    initDataForOutcome().createHearing()
 
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 25, 10, 0)
@@ -154,7 +154,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `amend a hearing fails on prison api and does not update the hearing `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForHearings().createHearing()
+    initDataForOutcome().createHearing()
 
     prisonApiMockServer.stubAmendHearingFailure(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     val dateTimeOfHearing = LocalDateTime.of(2010, 10, 25, 10, 0)
@@ -188,7 +188,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `delete a hearing `() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForHearings().createHearing()
+    initDataForOutcome().createHearing()
     prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
     webTestClient.delete()
@@ -205,7 +205,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `delete a hearing fails on prison api and does not delete record`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForHearings().createHearing()
+    initDataForOutcome().createHearing()
 
     prisonApiMockServer.stubDeleteHearingFailure(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
@@ -229,7 +229,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing()
+    initDataForOutcome().createHearing()
 
     webTestClient.post()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/adjourn")
@@ -265,7 +265,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `create hearing outcome for referral`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForHearings().createHearing()
+    initDataForOutcome().createHearing()
 
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
@@ -300,7 +300,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `referral transaction is rolled back when hearing outcome succeeds and outcome creation fails`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForHearings().createHearing()
+    initDataForOutcome().createHearing()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/status")
@@ -342,7 +342,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
   @Test
   fun `get all hearings`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForHearings().createHearing()
+    initDataForOutcome().createHearing()
 
     webTestClient.get()
       .uri("/reported-adjudications/hearings?hearingDate=${IntegrationTestData.DEFAULT_ADJUDICATION.dateTimeOfHearing!!.toLocalDate()}")
@@ -370,7 +370,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing().createAdjourn()
+    initDataForOutcome().createHearing().createAdjourn()
 
     webTestClient.delete()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/outcome/adjourn")
@@ -389,7 +389,7 @@ class HearingsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing().createAdjourn()
+    initDataForOutcome().createHearing().createAdjourn()
 
     webTestClient.post()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/hearing/v2")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestBase.kt
@@ -146,7 +146,7 @@ abstract class IntegrationTestBase : TestBase() {
     return intTestData
   }
 
-  protected fun initDataForOutcome(adjudication: AdjudicationIntTestDataSet = IntegrationTestData.DEFAULT_ADJUDICATION): IntegrationTestScenario {
+  protected fun initDataForUnScheduled(adjudication: AdjudicationIntTestDataSet = IntegrationTestData.DEFAULT_ADJUDICATION): IntegrationTestScenario {
     prisonApiMockServer.stubPostAdjudication(adjudication)
 
     val intTestData = integrationTestData()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestBase.kt
@@ -146,32 +146,6 @@ abstract class IntegrationTestBase : TestBase() {
     return intTestData
   }
 
-  protected fun initDataForHearings(): IntegrationTestScenario {
-    val testData = IntegrationTestData.DEFAULT_ADJUDICATION
-    prisonApiMockServer.stubPostAdjudication(testData)
-
-    val intTestData = integrationTestData()
-    val draftUserHeaders = setHeaders(username = testData.createdByUserId)
-
-    val draftIntTestScenarioBuilder = IntegrationTestScenarioBuilder(
-      intTestData = intTestData,
-      intTestBase = this,
-      headers = draftUserHeaders,
-    )
-
-    return draftIntTestScenarioBuilder
-      .startDraft(testData)
-      .setApplicableRules()
-      .setIncidentRole()
-      .setOffenceData()
-      .addIncidentStatement()
-      .addDamages()
-      .addEvidence()
-      .addWitnesses()
-      .completeDraft()
-      .acceptReport(testData.chargeNumber, testData.agencyId)
-  }
-
   protected fun initDataForOutcome(adjudication: AdjudicationIntTestDataSet = IntegrationTestData.DEFAULT_ADJUDICATION): IntegrationTestScenario {
     prisonApiMockServer.stubPostAdjudication(adjudication)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/MigrateExistingIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/MigrateExistingIntTest.kt
@@ -101,7 +101,7 @@ class MigrateExistingIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubNomisHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber, 100)
 
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     webTestClient.put()
       .uri("/scheduled-tasks/check-nomis-created-hearing-outcomes-for-locking")
@@ -136,7 +136,7 @@ class MigrateExistingIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubNomisHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber, 100)
 
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     webTestClient.put()
       .uri("/scheduled-tasks/check-nomis-created-hearing-outcomes-for-locking")
@@ -170,7 +170,7 @@ class MigrateExistingIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubNomisHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber, 100)
     prisonApiMockServer.stubNomisHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber, 101)
 
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     // note: need to run this, as cant create 2 hearings without results
     webTestClient.put()
@@ -225,7 +225,7 @@ class MigrateExistingIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
     val dateTimeOfHearing = LocalDateTime.of(2023, 8, 1, 1, 1, 0)
-    initDataForOutcome().createHearing().createChargeProved()
+    initDataForUnScheduled().createHearing().createChargeProved()
     val dto = getExistingRecord(
       oicIncidentId = IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber.toLong(),
       prisonerNumber = IntegrationTestData.DEFAULT_ADJUDICATION.prisonerNumber,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/MigrateExistingIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/MigrateExistingIntTest.kt
@@ -102,7 +102,7 @@ class MigrateExistingIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubNomisHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber, 100)
 
-    initDataForHearings().createHearing()
+    initDataForOutcome().createHearing()
 
     webTestClient.put()
       .uri("/scheduled-tasks/check-nomis-created-hearing-outcomes-for-locking")
@@ -137,7 +137,7 @@ class MigrateExistingIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubNomisHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber, 100)
 
-    initDataForHearings().createHearing()
+    initDataForOutcome().createHearing()
 
     webTestClient.put()
       .uri("/scheduled-tasks/check-nomis-created-hearing-outcomes-for-locking")
@@ -171,7 +171,7 @@ class MigrateExistingIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubNomisHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber, 100)
     prisonApiMockServer.stubNomisHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber, 101)
 
-    initDataForHearings().createHearing()
+    initDataForOutcome().createHearing()
 
     // note: need to run this, as cant create 2 hearings without results
     webTestClient.put()
@@ -225,7 +225,7 @@ class MigrateExistingIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing().createChargeProved()
+    initDataForOutcome().createHearing().createChargeProved()
     val dto = getExistingRecord(
       oicIncidentId = IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber.toLong(),
       prisonerNumber = IntegrationTestData.DEFAULT_ADJUDICATION.prisonerNumber,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/MigrateExistingIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/MigrateExistingIntTest.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.Finding
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.gateways.OicHearingType
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.utils.MigrationEntityBuilder
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 class MigrateExistingIntTest : SqsIntegrationTestBase() {
   @BeforeEach
@@ -225,11 +224,14 @@ class MigrateExistingIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
+    val dateTimeOfHearing = LocalDateTime.of(2023, 8, 1, 1, 1, 0)
     initDataForOutcome().createHearing().createChargeProved()
     val dto = getExistingRecord(
       oicIncidentId = IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber.toLong(),
       prisonerNumber = IntegrationTestData.DEFAULT_ADJUDICATION.prisonerNumber,
+      dateTimeOfHearing = dateTimeOfHearing,
     )
+
     migrateRecord(dto = dto)
 
     webTestClient.get()
@@ -238,23 +240,20 @@ class MigrateExistingIntTest : SqsIntegrationTestBase() {
       .exchange()
       .expectStatus().isOk
       .expectBody()
-      .jsonPath("$.reportedAdjudication.hearings[0].dateTimeOfHearing").isEqualTo(
-        dto.hearings.first().hearingDateTime.format(
-          DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"),
-        ),
-      )
+      .jsonPath("$.reportedAdjudication.hearings[0].dateTimeOfHearing").isEqualTo("2023-08-01T01:01:00")
       .jsonPath("$.reportedAdjudication.hearings[0].locationId").isEqualTo(dto.hearings.first().locationId)
       .jsonPath("$.reportedAdjudication.hearings[0].oicHearingType").isEqualTo(dto.hearings.first().oicHearingType.name)
       .jsonPath("$.reportedAdjudication.hearings[0].outcome.adjudicator").isEqualTo(dto.hearings.first().adjudicator!!)
   }
 
   companion object {
-    fun getExistingRecord(oicIncidentId: Long, prisonerNumber: String, offenceCode: String = "51:4") = MigrationEntityBuilder().createAdjudication(
+    fun getExistingRecord(oicIncidentId: Long, prisonerNumber: String, offenceCode: String = "51:4", dateTimeOfHearing: LocalDateTime = LocalDateTime.now()) = MigrationEntityBuilder().createAdjudication(
       oicIncidentId = oicIncidentId,
       offence = MigrationEntityBuilder().createOffence(offenceCode = offenceCode, offenceDescription = "updated desc"),
       prisoner = MigrationEntityBuilder().createPrisoner(prisonerNumber = prisonerNumber),
       hearings = listOf(
         MigrationEntityBuilder().createHearing(
+          hearingDateTime = dateTimeOfHearing,
           oicHearingId = 100,
           hearingResult = MigrationEntityBuilder().createHearingResult(),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/MigrateResetIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/MigrateResetIntTest.kt
@@ -74,7 +74,7 @@ class MigrateResetIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubNomisHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber, 100)
 
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     webTestClient.put()
       .uri("/scheduled-tasks/check-nomis-created-hearing-outcomes-for-locking")
@@ -111,7 +111,7 @@ class MigrateResetIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createChargeProved()
+    initDataForUnScheduled().createHearing().createChargeProved()
     integrationTestData().createPunishments(testDataSet = IntegrationTestData.DEFAULT_ADJUDICATION).expectStatus().isCreated
 
     migrateRecord(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/MigrateResetIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/MigrateResetIntTest.kt
@@ -74,7 +74,7 @@ class MigrateResetIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubNomisHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber, 100)
 
-    initDataForHearings().createHearing()
+    initDataForOutcome().createHearing()
 
     webTestClient.put()
       .uri("/scheduled-tasks/check-nomis-created-hearing-outcomes-for-locking")
@@ -111,7 +111,7 @@ class MigrateResetIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing().createChargeProved()
+    initDataForOutcome().createHearing().createChargeProved()
     integrationTestData().createPunishments(testDataSet = IntegrationTestData.DEFAULT_ADJUDICATION).expectStatus().isCreated
 
     migrateRecord(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
@@ -376,7 +376,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing().createReferral(HearingOutcomeCode.REFER_POLICE).createOutcomeNotProceed()
+    initDataForOutcome().createHearing().createReferral(HearingOutcomeCode.REFER_POLICE).createOutcomeNotProceed()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/outcome")
@@ -403,7 +403,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD).createOutcomeReferGov()
+    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD).createOutcomeReferGov()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/outcome")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/OutcomeIntTest.kt
@@ -20,7 +20,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `create outcome - not proceed`() {
-    initDataForOutcome()
+    initDataForUnScheduled()
 
     webTestClient.post()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/outcome/not-proceed")
@@ -47,7 +47,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `delete an outcome - not proceed `() {
-    initDataForOutcome().createOutcomeNotProceed().expectStatus().isCreated
+    initDataForUnScheduled().createOutcomeNotProceed().expectStatus().isCreated
 
     webTestClient.delete()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/outcome")
@@ -61,7 +61,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `refer to police leads to police prosecution`() {
-    initDataForOutcome().createOutcomeReferPolice()
+    initDataForUnScheduled().createOutcomeReferPolice()
 
     integrationTestData().createOutcomeProsecution(
       IntegrationTestData.DEFAULT_ADJUDICATION,
@@ -78,7 +78,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
   @Test
   fun `create completed hearing outcome - not proceed`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
@@ -109,7 +109,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
   @Test
   fun `create completed hearing outcome - dismissed`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
@@ -138,7 +138,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
   @Test
   fun `create completed hearing outcome - charge proved v2`() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
@@ -165,7 +165,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `create completed hearing outcome - dismissed throws exception when hearing is missing`() {
-    initDataForOutcome()
+    initDataForUnScheduled()
 
     webTestClient.post()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/complete-hearing/dismissed")
@@ -183,7 +183,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `create completed hearing outcome - not proceed throws exception when hearing is missing`() {
-    initDataForOutcome()
+    initDataForUnScheduled()
 
     webTestClient.post()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/complete-hearing/not-proceed")
@@ -202,7 +202,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `create completed hearing outcome - charge proved throws exception when hearing is missing`() {
-    initDataForOutcome()
+    initDataForUnScheduled()
 
     webTestClient.post()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/complete-hearing/charge-proved")
@@ -226,7 +226,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubDeleteSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createChargeProved()
+    initDataForUnScheduled().createHearing().createChargeProved()
 
     webTestClient.delete()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/remove-completed-hearing")
@@ -246,7 +246,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
 
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createChargeProved()
+    initDataForUnScheduled().createHearing().createChargeProved()
 
     webTestClient.post()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/outcome/quashed")
@@ -280,7 +280,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubDeleteSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createChargeProved().createQuashed()
+    initDataForUnScheduled().createHearing().createChargeProved().createQuashed()
 
     webTestClient.delete()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/outcome")
@@ -296,7 +296,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `amend outcome - not proceed without hearing `() {
-    initDataForOutcome().createOutcomeNotProceed()
+    initDataForUnScheduled().createOutcomeNotProceed()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/outcome")
@@ -320,7 +320,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `amend outcome - refer police without hearing `() {
-    initDataForOutcome().createOutcomeReferPolice()
+    initDataForUnScheduled().createOutcomeReferPolice()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/outcome")
@@ -347,7 +347,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubQuashSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createChargeProved().createQuashed()
+    initDataForUnScheduled().createHearing().createChargeProved().createQuashed()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/outcome")
@@ -376,7 +376,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createReferral(HearingOutcomeCode.REFER_POLICE).createOutcomeNotProceed()
+    initDataForUnScheduled().createHearing().createReferral(HearingOutcomeCode.REFER_POLICE).createOutcomeNotProceed()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/outcome")
@@ -403,7 +403,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD).createOutcomeReferGov()
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD).createOutcomeReferGov()
 
     webTestClient.put()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/outcome")
@@ -429,7 +429,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubDeleteHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createOutcomeReferPolice()
+    initDataForUnScheduled().createOutcomeReferPolice()
       .createHearing(dateTimeOfHearing = LocalDateTime.now())
       .createAdjourn()
       .createHearing(dateTimeOfHearing = LocalDateTime.now().plusDays(1))
@@ -459,7 +459,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome()
+    initDataForUnScheduled()
       .createOutcomeReferPolice()
       .createHearing(dateTimeOfHearing = LocalDateTime.now())
       .createAdjourn()
@@ -498,7 +498,7 @@ class OutcomeIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubDeleteSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome()
+    initDataForUnScheduled()
       .createHearing(dateTimeOfHearing = LocalDateTime.now())
       .createChargeProved()
       .createPunishments()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/PunishmentsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/PunishmentsIntTest.kt
@@ -28,7 +28,7 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing().createChargeProved()
+    initDataForUnScheduled().createHearing().createChargeProved()
 
     createPunishments()
       .expectStatus().isCreated
@@ -47,7 +47,7 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.INAD_ADULT).createChargeProved()
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.INAD_ADULT).createChargeProved()
 
     createPunishments(type = PunishmentType.ADDITIONAL_DAYS, consecutiveReportNumber = "9999")
       .expectStatus().isCreated
@@ -62,7 +62,7 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubUpdateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing().createChargeProved()
+    initDataForUnScheduled().createHearing().createChargeProved()
 
     val suspendedUntil = LocalDate.now().plusMonths(1)
     val formattedDate = suspendedUntil.format(DateTimeFormatter.ISO_DATE)
@@ -140,8 +140,8 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.ADJUDICATION_2.chargeNumber)
 
-    initDataForOutcome().createHearing().createChargeProved()
-    initDataForOutcome(adjudication = IntegrationTestData.ADJUDICATION_2).createHearing(oicHearingType = OicHearingType.INAD_YOI, dateTimeOfHearing = LocalDateTime.now().plusDays(1), overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
+    initDataForUnScheduled().createHearing().createChargeProved()
+    initDataForUnScheduled(adjudication = IntegrationTestData.ADJUDICATION_2).createHearing(oicHearingType = OicHearingType.INAD_YOI, dateTimeOfHearing = LocalDateTime.now().plusDays(1), overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
       .createChargeProved(overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
 
     val result = createPunishments(type = PunishmentType.REMOVAL_WING)
@@ -195,8 +195,8 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.ADJUDICATION_2.chargeNumber)
 
-    initDataForOutcome().createHearing().createChargeProved()
-    initDataForOutcome(adjudication = IntegrationTestData.ADJUDICATION_2).createHearing(oicHearingType = OicHearingType.INAD_YOI, dateTimeOfHearing = LocalDateTime.now().plusDays(1), overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
+    initDataForUnScheduled().createHearing().createChargeProved()
+    initDataForUnScheduled(adjudication = IntegrationTestData.ADJUDICATION_2).createHearing(oicHearingType = OicHearingType.INAD_YOI, dateTimeOfHearing = LocalDateTime.now().plusDays(1), overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
       .createChargeProved(overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
 
     val result = createPunishments(type = PunishmentType.REMOVAL_WING)
@@ -248,7 +248,7 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateSanction(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing().createChargeProved()
+    initDataForUnScheduled().createHearing().createChargeProved()
 
     createPunishments()
       .expectStatus().isCreated
@@ -279,8 +279,8 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.ADJUDICATION_2.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.INAD_ADULT).createChargeProved()
-    initDataForOutcome(adjudication = IntegrationTestData.ADJUDICATION_2).createHearing(oicHearingType = OicHearingType.INAD_YOI, dateTimeOfHearing = IntegrationTestData.DEFAULT_ADJUDICATION.dateTimeOfHearing, overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.INAD_ADULT).createChargeProved()
+    initDataForUnScheduled(adjudication = IntegrationTestData.ADJUDICATION_2).createHearing(oicHearingType = OicHearingType.INAD_YOI, dateTimeOfHearing = IntegrationTestData.DEFAULT_ADJUDICATION.dateTimeOfHearing, overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
 
     webTestClient.post()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/punishments/v2")
@@ -314,7 +314,7 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `create punishment comment `() {
-    initDataForOutcome()
+    initDataForUnScheduled()
 
     createPunishmentComment()
       .expectStatus().isCreated
@@ -327,7 +327,7 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `update punishment comment `() {
-    initDataForOutcome()
+    initDataForUnScheduled()
 
     val reportedAdjudicationResponse = webTestClient.post()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/punishments/comment")
@@ -360,7 +360,7 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `delete punishment comment `() {
-    initDataForOutcome()
+    initDataForUnScheduled()
 
     val reportedAdjudicationResponse = webTestClient.post()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/punishments/comment")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReferralsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReferralsIntTest.kt
@@ -27,7 +27,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubDeleteHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = if (hearingOutcomeCode == HearingOutcomeCode.REFER_GOV) OicHearingType.INAD_ADULT else OicHearingType.GOV_ADULT).createReferral(hearingOutcomeCode)
+    initDataForOutcome().createHearing(oicHearingType = if (hearingOutcomeCode == HearingOutcomeCode.REFER_GOV) OicHearingType.INAD_ADULT else OicHearingType.GOV_ADULT).createReferral(hearingOutcomeCode)
 
     webTestClient.delete()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/remove-referral")
@@ -45,7 +45,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubDeleteHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = if (hearingOutcomeCode == HearingOutcomeCode.REFER_GOV) OicHearingType.INAD_ADULT else OicHearingType.GOV_ADULT).createReferral(hearingOutcomeCode)
+    initDataForOutcome().createHearing(oicHearingType = if (hearingOutcomeCode == HearingOutcomeCode.REFER_GOV) OicHearingType.INAD_ADULT else OicHearingType.GOV_ADULT).createReferral(hearingOutcomeCode)
       .createOutcomeNotProceed().expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
@@ -336,7 +336,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
+    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
       .createOutcomeReferGov().expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
@@ -350,7 +350,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = OicHearingType.INAD_ADULT).createReferral(HearingOutcomeCode.REFER_GOV)
+    initDataForOutcome().createHearing(oicHearingType = OicHearingType.INAD_ADULT).createReferral(HearingOutcomeCode.REFER_GOV)
       .createOutcomeNotProceed().expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
@@ -364,7 +364,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = OicHearingType.INAD_ADULT).createReferral(HearingOutcomeCode.REFER_GOV)
+    initDataForOutcome().createHearing(oicHearingType = OicHearingType.INAD_ADULT).createReferral(HearingOutcomeCode.REFER_GOV)
 
     integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION, LocalDateTime.now().plusDays(1))
       .expectStatus().isCreated
@@ -381,7 +381,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
+    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
       .createOutcomeReferGov().expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
@@ -403,7 +403,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
+    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
       .createOutcomeReferGov().expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
@@ -428,7 +428,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
+    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
       .createOutcomeReferGov().expectStatus().isCreated
       .expectBody()
 
@@ -456,7 +456,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubQuashSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
+    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
       .createOutcomeReferGov().expectStatus().isCreated
       .expectBody()
 
@@ -486,7 +486,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
+    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
       .createReferral(HearingOutcomeCode.REFER_INAD)
 
     integrationTestData().createHearing(
@@ -546,7 +546,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
+    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
       .createReferral(HearingOutcomeCode.REFER_INAD)
 
     integrationTestData().createHearing(
@@ -594,7 +594,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubQuashSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
+    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
       .createReferral(HearingOutcomeCode.REFER_INAD)
 
     integrationTestData().createHearing(
@@ -646,7 +646,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
+    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
       .createReferral(HearingOutcomeCode.REFER_INAD)
 
     integrationTestData().createHearing(
@@ -695,7 +695,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
+    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
       .createOutcomeReferGov().expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
@@ -721,7 +721,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForHearings().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
+    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
       .createOutcomeReferGov().expectStatus().isCreated
 
     integrationTestData().createHearing(testDataSet = IntegrationTestData.DEFAULT_ADJUDICATION, oicHearingType = OicHearingType.GOV_ADULT, dateTimeOfHearing = LocalDateTime.now().plusDays(3))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReferralsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ReferralsIntTest.kt
@@ -27,7 +27,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubDeleteHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = if (hearingOutcomeCode == HearingOutcomeCode.REFER_GOV) OicHearingType.INAD_ADULT else OicHearingType.GOV_ADULT).createReferral(hearingOutcomeCode)
+    initDataForUnScheduled().createHearing(oicHearingType = if (hearingOutcomeCode == HearingOutcomeCode.REFER_GOV) OicHearingType.INAD_ADULT else OicHearingType.GOV_ADULT).createReferral(hearingOutcomeCode)
 
     webTestClient.delete()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/remove-referral")
@@ -45,7 +45,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubDeleteHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = if (hearingOutcomeCode == HearingOutcomeCode.REFER_GOV) OicHearingType.INAD_ADULT else OicHearingType.GOV_ADULT).createReferral(hearingOutcomeCode)
+    initDataForUnScheduled().createHearing(oicHearingType = if (hearingOutcomeCode == HearingOutcomeCode.REFER_GOV) OicHearingType.INAD_ADULT else OicHearingType.GOV_ADULT).createReferral(hearingOutcomeCode)
       .createOutcomeNotProceed().expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
@@ -66,7 +66,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `remove referral without hearing`() {
-    initDataForOutcome().createOutcomeReferPolice()
+    initDataForUnScheduled().createOutcomeReferPolice()
 
     webTestClient.delete()
       .uri("/reported-adjudications/${IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber}/remove-referral")
@@ -80,7 +80,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `remove referral and referral outcome`() {
-    initDataForOutcome().createOutcomeReferPolice()
+    initDataForUnScheduled().createOutcomeReferPolice()
 
     integrationTestData().createOutcomeProsecution(
       IntegrationTestData.DEFAULT_ADJUDICATION,
@@ -104,7 +104,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `create police referral without hearing, schedule a new hearing and then remove it`() {
-    initDataForOutcome().createOutcomeReferPolice()
+    initDataForUnScheduled().createOutcomeReferPolice()
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
     integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION)
@@ -125,7 +125,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `remove referral, referral outcome and hearing outcome for a POLICE_REFER related to complex example, police refer - no hearing, inad refer, police refer, prosecute`() {
-    initDataForOutcome().createOutcomeReferPolice()
+    initDataForUnScheduled().createOutcomeReferPolice()
 
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
@@ -183,7 +183,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `create hearing, refer to inad, and inad decides not to proceed, then remove referral`() {
-    initDataForOutcome()
+    initDataForUnScheduled()
 
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
@@ -219,7 +219,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `create hearing, refer to inad, schedule inad hearing, then remove the hearing`() {
-    initDataForOutcome()
+    initDataForUnScheduled()
 
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
@@ -256,7 +256,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `create hearing, refer to police, schedule hearing, then remove the hearing`() {
-    initDataForOutcome()
+    initDataForUnScheduled()
 
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
@@ -294,7 +294,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `police refer from hearing leads to prosecution, then referral is removed`() {
-    initDataForOutcome()
+    initDataForUnScheduled()
 
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
@@ -336,7 +336,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
       .createOutcomeReferGov().expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
@@ -350,7 +350,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.INAD_ADULT).createReferral(HearingOutcomeCode.REFER_GOV)
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.INAD_ADULT).createReferral(HearingOutcomeCode.REFER_GOV)
       .createOutcomeNotProceed().expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
@@ -364,7 +364,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.INAD_ADULT).createReferral(HearingOutcomeCode.REFER_GOV)
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.INAD_ADULT).createReferral(HearingOutcomeCode.REFER_GOV)
 
     integrationTestData().createHearing(IntegrationTestData.DEFAULT_ADJUDICATION, LocalDateTime.now().plusDays(1))
       .expectStatus().isCreated
@@ -381,7 +381,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
       .createOutcomeReferGov().expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
@@ -403,7 +403,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
       .createOutcomeReferGov().expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
@@ -428,7 +428,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
       .createOutcomeReferGov().expectStatus().isCreated
       .expectBody()
 
@@ -456,7 +456,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubQuashSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
       .createOutcomeReferGov().expectStatus().isCreated
       .expectBody()
 
@@ -486,7 +486,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
       .createReferral(HearingOutcomeCode.REFER_INAD)
 
     integrationTestData().createHearing(
@@ -546,7 +546,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
       .createReferral(HearingOutcomeCode.REFER_INAD)
 
     integrationTestData().createHearing(
@@ -594,7 +594,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubQuashSanctions(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
       .createReferral(HearingOutcomeCode.REFER_INAD)
 
     integrationTestData().createHearing(
@@ -646,7 +646,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.GOV_ADULT)
       .createReferral(HearingOutcomeCode.REFER_INAD)
 
     integrationTestData().createHearing(
@@ -695,7 +695,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubAmendHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
       .createOutcomeReferGov().expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.outcomes.size()").isEqualTo(1)
@@ -721,7 +721,7 @@ class ReferralsIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubDeleteHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
     prisonApiMockServer.stubCreateHearingResult(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
 
-    initDataForOutcome().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
+    initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.GOV_ADULT).createReferral(HearingOutcomeCode.REFER_INAD)
       .createOutcomeReferGov().expectStatus().isCreated
 
     integrationTestData().createHearing(testDataSet = IntegrationTestData.DEFAULT_ADJUDICATION, oicHearingType = OicHearingType.GOV_ADULT, dateTimeOfHearing = LocalDateTime.now().plusDays(3))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/TransfersIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/TransfersIntTest.kt
@@ -22,7 +22,7 @@ class TransfersIntTest : SqsIntegrationTestBase() {
   fun setUp() {
     setAuditTime()
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForHearings().createHearing()
+    initDataForOutcome().createHearing()
 
     domainEventsTopicSnsClient.publish(
       PublishRequest.builder()
@@ -178,7 +178,7 @@ class TransfersIntTest : SqsIntegrationTestBase() {
   fun `get all reports for transfers only `() {
     Thread.sleep(1000)
 
-    initDataForHearings()
+    initDataForOutcome()
 
     webTestClient.get()
       .uri("/reported-adjudications/reports?startDate=2010-11-10&endDate=2010-11-13&status=SCHEDULED,UNSCHEDULED&transfersOnly=true&page=0&size=20")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/TransfersIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/TransfersIntTest.kt
@@ -22,7 +22,7 @@ class TransfersIntTest : SqsIntegrationTestBase() {
   fun setUp() {
     setAuditTime()
     prisonApiMockServer.stubCreateHearing(IntegrationTestData.DEFAULT_ADJUDICATION.chargeNumber)
-    initDataForOutcome().createHearing()
+    initDataForUnScheduled().createHearing()
 
     domainEventsTopicSnsClient.publish(
       PublishRequest.builder()
@@ -178,7 +178,7 @@ class TransfersIntTest : SqsIntegrationTestBase() {
   fun `get all reports for transfers only `() {
     Thread.sleep(1000)
 
-    initDataForOutcome()
+    initDataForUnScheduled()
 
     webTestClient.get()
       .uri("/reported-adjudications/reports?startDate=2010-11-10&endDate=2010-11-13&status=SCHEDULED,UNSCHEDULED&transfersOnly=true&page=0&size=20")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/migrate/MigrateExistingRecordServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/migrate/MigrateExistingRecordServiceTest.kt
@@ -366,6 +366,20 @@ class MigrateExistingRecordServiceTest : ReportedAdjudicationTestBase() {
       assertThat(argumentCaptor.value.hearings[1].hearingOutcome!!.reason).isEqualTo(HearingOutcomeAdjournReason.OTHER)
       assertThat(argumentCaptor.value.hearings.last().hearingOutcome).isNull()
     }
+
+    @Test
+    fun `ignores empty hearings list`() {
+      val argumentCaptor = ArgumentCaptor.forClass(ReportedAdjudication::class.java)
+      val dto = migrationFixtures.ADULT_SINGLE_OFFENCE
+      val existing = existing(dto).also {
+        it.hearings.clear()
+      }
+
+      migrateExistingRecordService.accept(dto, existing)
+      verify(reportedAdjudicationRepository).save(argumentCaptor.capture())
+
+      assertThat(argumentCaptor.value.hearings.isEmpty()).isTrue
+    }
   }
 
   @Nested


### PR DESCRIPTION
also tidy up int tests (remove duplicate function) and bug fix for migration - hearings can be empty