### PR TITLE
NN-5942 remove offence version variable from api and switch to front end

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/draft/DraftOffenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/draft/DraftOffenceController.kt
@@ -78,9 +78,10 @@ class DraftOffenceController(
   fun getOffenceRules(
     @RequestParam(value = "youthOffender") isYouthOffender: Boolean,
     @RequestParam(value = "gender", required = false) gender: Gender?,
-    @RequestParam(value = "version", required = false) version: Int?,
+    @RequestParam(value = "version") version: Int,
   ): List<OffenceRuleDetailsDto> = incidentOffenceService.getRules(
     isYouthOffender = isYouthOffender,
     gender = gender ?: Gender.MALE,
+    version = version,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/OffenceCodeLookupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/OffenceCodeLookupService.kt
@@ -4,8 +4,8 @@ import org.springframework.stereotype.Service
 
 @Service
 class OffenceCodeLookupService {
-  private val youthOffenceCodes: List<OffenceCodes> = getYouthOffenceCodes()
-  private val adultOffenceCodes: List<OffenceCodes> = getAdultOffenceCodes()
+  private val youthOffenceCodes: List<OffenceCodes> = OffenceCodes.values().filter { it.nomisCode.startsWith("55:") }
+  private val adultOffenceCodes: List<OffenceCodes> = OffenceCodes.values().filter { it.nomisCode.startsWith("51:") }
 
   fun getOffenceCode(offenceCode: Int, isYouthOffender: Boolean): OffenceCodes =
     when (isYouthOffender) {
@@ -15,7 +15,4 @@ class OffenceCodeLookupService {
 
   fun getAdultOffenceCodesByVersion(version: Int) = adultOffenceCodes.filter { it.applicableVersions.contains(version) }
   fun getYouthOffenceCodesByVersion(version: Int) = youthOffenceCodes.filter { it.applicableVersions.contains(version) }
-
-  private fun getAdultOffenceCodes() = OffenceCodes.values().filter { it.nomisCode.startsWith("51:") }
-  private fun getYouthOffenceCodes() = OffenceCodes.values().filter { it.nomisCode.startsWith("55:") }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/OffenceCodeLookupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/OffenceCodeLookupService.kt
@@ -1,17 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services
 
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 
 @Service
-class OffenceCodeLookupService(
-  @Value("\${service.offences.version}")
-  val offencesVersion: Int,
-) {
-  val youthOffenceCodes: List<OffenceCodes>
-    get() = getYouthOffenceCodes(offencesVersion)
-  val adultOffenceCodes: List<OffenceCodes>
-    get() = getAdultOffenceCodes(offencesVersion)
+class OffenceCodeLookupService {
+  private val youthOffenceCodes: List<OffenceCodes> = getYouthOffenceCodes()
+  private val adultOffenceCodes: List<OffenceCodes> = getAdultOffenceCodes()
 
   fun getOffenceCode(offenceCode: Int, isYouthOffender: Boolean): OffenceCodes =
     when (isYouthOffender) {
@@ -19,6 +13,9 @@ class OffenceCodeLookupService(
       false -> adultOffenceCodes.firstOrNull { it.uniqueOffenceCodes.contains(offenceCode) }
     } ?: OffenceCodes.MIGRATED_OFFENCE
 
-  private fun getAdultOffenceCodes(version: Int) = OffenceCodes.values().filter { it.nomisCode.startsWith("51:") && it.applicableVersions.contains(version) }
-  private fun getYouthOffenceCodes(version: Int) = OffenceCodes.values().filter { it.nomisCode.startsWith("55:") && it.applicableVersions.contains(version) }
+  fun getAdultOffenceCodesByVersion(version: Int) = adultOffenceCodes.filter { it.applicableVersions.contains(version) }
+  fun getYouthOffenceCodesByVersion(version: Int) = youthOffenceCodes.filter { it.applicableVersions.contains(version) }
+
+  private fun getAdultOffenceCodes() = OffenceCodes.values().filter { it.nomisCode.startsWith("51:") }
+  private fun getYouthOffenceCodes() = OffenceCodes.values().filter { it.nomisCode.startsWith("55:") }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/draft/DraftOffenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/draft/DraftOffenceService.kt
@@ -37,10 +37,10 @@ class DraftOffenceService(
     )
   }
 
-  fun getRules(isYouthOffender: Boolean, gender: Gender): List<OffenceRuleDetailsDto> =
+  fun getRules(isYouthOffender: Boolean, gender: Gender, version: Int): List<OffenceRuleDetailsDto> =
     when (isYouthOffender) {
-      true -> offenceCodeLookupService.youthOffenceCodes
-      false -> offenceCodeLookupService.adultOffenceCodes
+      true -> offenceCodeLookupService.getYouthOffenceCodesByVersion(version)
+      false -> offenceCodeLookupService.getAdultOffenceCodesByVersion(version)
     }.distinctBy { it.paragraph }.map {
       OffenceRuleDetailsDto(
         paragraphNumber = it.paragraph,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,8 +83,6 @@ api:
   health-timeout-ms: 1000
 
 service:
-  offences:
-    version: ${SERVICE_OFFENCES_VERSION:1}
   active:
     prisons: ${SERVICE_ACTIVE_PRISONS:***}
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/draft/DraftOffenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/draft/DraftOffenceControllerTest.kt
@@ -139,13 +139,13 @@ class DraftOffenceControllerTest : TestControllerBase() {
       getAllOffenceRulesRequest()
         .andExpect(MockMvcResultMatchers.status().isOk)
 
-      verify(incidentOffenceService, atLeastOnce()).getRules(any(), any())
+      verify(incidentOffenceService, atLeastOnce()).getRules(any(), any(), any())
     }
 
     private fun getAllOffenceRulesRequest(): ResultActions {
       return mockMvc
         .perform(
-          MockMvcRequestBuilders.get("/draft-adjudications/offence-rules?youthOffender=false")
+          MockMvcRequestBuilders.get("/draft-adjudications/offence-rules?youthOffender=false&version=1")
             .header("Content-Type", "application/json"),
         )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/DraftAdjudicationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/DraftAdjudicationIntTest.kt
@@ -502,7 +502,7 @@ class DraftAdjudicationIntTest : SqsIntegrationTestBase() {
   @Test
   fun `gets all adult offence rules`() {
     webTestClient.get()
-      .uri("/draft-adjudications/offence-rules?youthOffender=false")
+      .uri("/draft-adjudications/offence-rules?youthOffender=false&version=1")
       .headers(setHeaders())
       .exchange()
       .expectStatus().isOk

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/OffenceCodeLookupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/OffenceCodeLookupServiceTest.kt
@@ -104,9 +104,8 @@ class OffenceCodeLookupServiceTest {
 
   @Test
   fun `get version 2 codes`() {
-    val offenceCodeLookupServiceV2 = OffenceCodeLookupService()
-    val adultOffences = offenceCodeLookupServiceV2.getAdultOffenceCodesByVersion(1)
-    val youthOffences = offenceCodeLookupServiceV2.getYouthOffenceCodesByVersion(1)
+    val adultOffences = offenceCodeLookupService.getAdultOffenceCodesByVersion(2)
+    val youthOffences = offenceCodeLookupService.getYouthOffenceCodesByVersion(2)
 
     assertThat(
       youthOffences.containsAll(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/OffenceCodeLookupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/OffenceCodeLookupServiceTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Gender
 
 class OffenceCodeLookupServiceTest {
-  private val offenceCodeLookupService: OffenceCodeLookupService = OffenceCodeLookupService(offencesVersion = 1)
+  private val offenceCodeLookupService: OffenceCodeLookupService = OffenceCodeLookupService()
 
   @Test
   fun `offence codes have values set for all items`() {
@@ -68,8 +68,8 @@ class OffenceCodeLookupServiceTest {
 
   @Test
   fun `get version 1 codes`() {
-    val adultOffences = offenceCodeLookupService.adultOffenceCodes
-    val youthOffences = offenceCodeLookupService.youthOffenceCodes
+    val adultOffences = offenceCodeLookupService.getAdultOffenceCodesByVersion(1)
+    val youthOffences = offenceCodeLookupService.getYouthOffenceCodesByVersion(1)
 
     assertThat(
       youthOffences.none {
@@ -104,9 +104,9 @@ class OffenceCodeLookupServiceTest {
 
   @Test
   fun `get version 2 codes`() {
-    val offenceCodeLookupServiceV2 = OffenceCodeLookupService(2)
-    val adultOffences = offenceCodeLookupServiceV2.adultOffenceCodes
-    val youthOffences = offenceCodeLookupServiceV2.youthOffenceCodes
+    val offenceCodeLookupServiceV2 = OffenceCodeLookupService()
+    val adultOffences = offenceCodeLookupServiceV2.getAdultOffenceCodesByVersion(1)
+    val youthOffences = offenceCodeLookupServiceV2.getYouthOffenceCodesByVersion(1)
 
     assertThat(
       youthOffences.containsAll(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/draft/DraftAdjudicationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/draft/DraftAdjudicationTestBase.kt
@@ -17,7 +17,7 @@ interface TestsToImplement {
 
 abstract class DraftAdjudicationTestBase : TestsToImplement {
   internal val draftAdjudicationRepository: DraftAdjudicationRepository = mock()
-  internal val offenceCodeLookupService: OffenceCodeLookupService = OffenceCodeLookupService(offencesVersion = 1)
+  internal val offenceCodeLookupService: OffenceCodeLookupService = OffenceCodeLookupService()
   internal val authenticationFacade: AuthenticationFacade = mock()
 
   @BeforeEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/draft/DraftOffenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/draft/DraftOffenceServiceTest.kt
@@ -154,16 +154,16 @@ class DraftOffenceServiceTest : DraftAdjudicationTestBase() {
 
   @Test
   fun `gets all offence adult rules`() {
-    val offenceRules = incidentOffenceService.getRules(isYouthOffender = false, gender = Gender.MALE)
+    val offenceRules = incidentOffenceService.getRules(isYouthOffender = false, gender = Gender.MALE, version = 1)
 
-    assertThat(offenceRules.size).isEqualTo(offenceCodeLookupService.adultOffenceCodes.distinctBy { it.paragraph }.size)
+    assertThat(offenceRules.size).isEqualTo(offenceCodeLookupService.getAdultOffenceCodesByVersion(1).distinctBy { it.paragraph }.size)
   }
 
   @Test
   fun `gets all yoi offence rules`() {
-    val offenceRules = incidentOffenceService.getRules(isYouthOffender = true, gender = Gender.MALE)
+    val offenceRules = incidentOffenceService.getRules(isYouthOffender = true, gender = Gender.MALE, version = 1)
 
-    assertThat(offenceRules.size).isEqualTo(offenceCodeLookupService.youthOffenceCodes.distinctBy { it.paragraph }.size)
+    assertThat(offenceRules.size).isEqualTo(offenceCodeLookupService.getYouthOffenceCodesByVersion(1).distinctBy { it.paragraph }.size)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationTestBase.kt
@@ -13,7 +13,7 @@ interface TestsToImplement {
   fun `throws an entity not found if the reported adjudication for the supplied id does not exists`()
 }
 abstract class ReportedAdjudicationTestBase : TestsToImplement {
-  internal val offenceCodeLookupService: OffenceCodeLookupService = OffenceCodeLookupService(offencesVersion = 1)
+  internal val offenceCodeLookupService: OffenceCodeLookupService = OffenceCodeLookupService()
   internal val authenticationFacade: AuthenticationFacade = mock()
   internal val reportedAdjudicationRepository: ReportedAdjudicationRepository = mock()
 


### PR DESCRIPTION
UI controls the version param,the issue regards the  ALO edit, which requires distinct versioned offences by para title, and all versioned offences have the same para as prior versions

For all other access within service (the toDto for draft and reported) its driven by the unique offence code which is not duplicated by version