### PR TITLE
SAA-1683 add check for historic data when deactivating

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -121,8 +121,12 @@ open class ReportedAdjudicationBaseService(
           .filter { p -> p.activatedByChargeNumber == chargeNumber && idsToUpdate.none { id -> id == it.id } }
           .forEach { punishmentToRestore ->
             punishmentToRestore.activatedByChargeNumber = null
-            punishmentToRestore.schedule.remove(punishmentToRestore.schedule.latestSchedule())
-            punishmentToRestore.suspendedUntil = punishmentToRestore.schedule.latestSchedule().suspendedUntil
+            val latestSchedule = punishmentToRestore.schedule.latestSchedule()
+            // this check is required until the historic data is corrected
+            if (punishmentToRestore.schedule.size > 1 && latestSchedule.suspendedUntil == null) {
+              punishmentToRestore.schedule.remove(latestSchedule)
+              punishmentToRestore.suspendedUntil = punishmentToRestore.schedule.latestSchedule().suspendedUntil
+            }
             suspendedPunishmentEvents.add(
               SuspendedPunishmentEvent(agencyId = it.originatingAgencyId, chargeNumber = it.chargeNumber, status = it.status),
             )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsServiceTest.kt
@@ -1396,7 +1396,7 @@ class PunishmentsServiceTest : ReportedAdjudicationTestBase() {
     }
 
     @Test
-    fun `deactivate punishment does not remove schedule when a record pre data fix (ie only one schedule present)`() {
+    fun `deactivate punishment does not remove schedule when a record pre data fix (ie only one schedule present, or more and the latest has a suspended until present)`() {
       whenever(reportedAdjudicationRepository.findByChargeNumber("current")).thenReturn(
         entityBuilder.reportedAdjudication(chargeNumber = "current").also {
           it.status = ReportedAdjudicationStatus.CHARGE_PROVED


### PR DESCRIPTION
historic data may only have one schedule.  It could have more, but as the data is cloned no need to remove the latest schedule