### PR TITLE
SAA-1676 quashed should deactivate activated suspended

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
@@ -173,9 +173,7 @@ class PunishmentsService(
         it.schedule.add(
           PunishmentSchedule(days = it.schedule.latestSchedule().days, startDate = punishment.startDate, endDate = punishment.endDate),
         )
-        suspendedPunishmentEvents.add(
-          SuspendedPunishmentEvent(agencyId = reportToUpdate.originatingAgencyId, chargeNumber = reportToUpdate.chargeNumber, status = reportToUpdate.status),
-        )
+        suspendedPunishmentEvents.add(SuspendedPunishmentEvent(agencyId = reportToUpdate.originatingAgencyId, chargeNumber = reportToUpdate.chargeNumber, status = reportToUpdate.status))
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
@@ -49,9 +49,7 @@ class PunishmentsService(
     if (punishmentsVersion == 2) {
       punishments.filter { it.activatedFrom != null }.let {
         if (it.isNotEmpty()) {
-          suspendedPunishmentEvents.addAll(
-            activateSuspendedPunishments(reportedAdjudication = reportedAdjudication, toActivate = it),
-          )
+          suspendedPunishmentEvents.addAll(activateSuspendedPunishments(reportedAdjudication = reportedAdjudication, toActivate = it))
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ActivatedPunishmentsV2IntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ActivatedPunishmentsV2IntTest.kt
@@ -140,7 +140,7 @@ class ActivatedPunishmentsV2IntTest : SqsIntegrationTestBase() {
   }
 
   @Test
-  fun `quashed deactivates an activated punishment, then unquashing it activates it`() {
+  fun `quashed deactivates an activated punishment `() {
     val activatedFrom = createSuspendedPunishmentCharge()
 
     val scenario = initDataForUnScheduled().createHearing().createChargeProved()
@@ -169,17 +169,6 @@ class ActivatedPunishmentsV2IntTest : SqsIntegrationTestBase() {
 
     confirmPunishmentIsDeActivated(
       chargeNumber = activatedFrom.first,
-    )
-
-    webTestClient.delete()
-      .uri("/reported-adjudications/${scenario.getGeneratedChargeNumber()}/outcome")
-      .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
-      .exchange()
-      .expectStatus().isOk
-
-    confirmPunishmentIsActivated(
-      chargeNumber = activatedFrom.first,
-      activatedByChargeNumber = scenario.getGeneratedChargeNumber(),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/PunishmentsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/PunishmentsIntTest.kt
@@ -123,11 +123,11 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `activate suspended punishment on create `() {
-    val scenario = initDataForUnScheduled().createHearing().createChargeProved()
-    val scenario2 = initDataForUnScheduled(adjudication = IntegrationTestData.ADJUDICATION_2).createHearing(oicHearingType = OicHearingType.INAD_YOI, dateTimeOfHearing = LocalDateTime.now().plusDays(1), overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
-      .createChargeProved(overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
+    val scenarioChargeNumber = initDataForUnScheduled().createHearing().createChargeProved().getGeneratedChargeNumber()
+    val scenario2 = initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.INAD_ADULT, dateTimeOfHearing = LocalDateTime.now().plusDays(1))
+      .createChargeProved()
 
-    val result = createPunishments(chargeNumber = scenario.getGeneratedChargeNumber(), type = PunishmentType.REMOVAL_WING)
+    val result = createPunishments(chargeNumber = scenarioChargeNumber, type = PunishmentType.REMOVAL_WING)
       .returnResult(ReportedAdjudicationResponse::class.java)
       .responseBody
       .blockFirst()!!
@@ -145,7 +145,7 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
                 days = 10,
                 startDate = LocalDate.now(),
                 endDate = LocalDate.now().plusDays(5),
-                activatedFrom = scenario.getGeneratedChargeNumber(),
+                activatedFrom = scenarioChargeNumber,
               ),
             ),
         ),
@@ -154,10 +154,10 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
       .expectStatus().isCreated
       .expectBody()
       .jsonPath("$.reportedAdjudication.punishments[0].type").isEqualTo(PunishmentType.REMOVAL_WING.name)
-      .jsonPath("$.reportedAdjudication.punishments[0].activatedFrom").isEqualTo(scenario.getGeneratedChargeNumber())
+      .jsonPath("$.reportedAdjudication.punishments[0].activatedFrom").isEqualTo(scenarioChargeNumber)
 
     webTestClient.get()
-      .uri("/reported-adjudications/${scenario.getGeneratedChargeNumber()}/v2")
+      .uri("/reported-adjudications/$scenarioChargeNumber/v2")
       .headers(setHeaders())
       .exchange()
       .expectStatus().is2xxSuccessful
@@ -168,11 +168,11 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
 
   @Test
   fun `activate suspended punishment on update `() {
-    val scenario = initDataForUnScheduled().createHearing().createChargeProved()
-    val scenario2 = initDataForUnScheduled(adjudication = IntegrationTestData.ADJUDICATION_2).createHearing(oicHearingType = OicHearingType.INAD_YOI, dateTimeOfHearing = LocalDateTime.now().plusDays(1), overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
-      .createChargeProved(overrideTestDataSet = IntegrationTestData.ADJUDICATION_2)
+    val scenarioChargeNumber = initDataForUnScheduled().createHearing().createChargeProved().getGeneratedChargeNumber()
+    val scenario2 = initDataForUnScheduled().createHearing(oicHearingType = OicHearingType.INAD_ADULT, dateTimeOfHearing = LocalDateTime.now().plusDays(1))
+      .createChargeProved()
 
-    val result = createPunishments(chargeNumber = scenario.getGeneratedChargeNumber(), type = PunishmentType.REMOVAL_WING)
+    val result = createPunishments(chargeNumber = scenarioChargeNumber, type = PunishmentType.REMOVAL_WING)
       .returnResult(ReportedAdjudicationResponse::class.java)
       .responseBody
       .blockFirst()!!
@@ -192,7 +192,7 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
                 days = 10,
                 startDate = LocalDate.now(),
                 endDate = LocalDate.now().plusDays(5),
-                activatedFrom = scenario.getGeneratedChargeNumber(),
+                activatedFrom = scenarioChargeNumber,
               ),
             ),
         ),
@@ -202,10 +202,10 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
       .expectBody()
       .jsonPath("$.reportedAdjudication.punishments.size()").isEqualTo(1)
       .jsonPath("$.reportedAdjudication.punishments[0].type").isEqualTo(PunishmentType.REMOVAL_WING.name)
-      .jsonPath("$.reportedAdjudication.punishments[0].activatedFrom").isEqualTo(scenario.getGeneratedChargeNumber())
+      .jsonPath("$.reportedAdjudication.punishments[0].activatedFrom").isEqualTo(scenarioChargeNumber)
 
     webTestClient.get()
-      .uri("/reported-adjudications/${scenario.getGeneratedChargeNumber()}/v2")
+      .uri("/reported-adjudications/$scenarioChargeNumber/v2")
       .headers(setHeaders())
       .exchange()
       .expectStatus().is2xxSuccessful

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/OutcomeServiceTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.atMost
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.ReportedAdjudicationDto
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.SuspendedPunishmentEvent
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Hearing
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcome
@@ -682,61 +683,6 @@ class OutcomeServiceTest : ReportedAdjudicationTestBase() {
       assertThat(activatedFrom.getPunishments().first().activatedByChargeNumber).isNull()
       assertThat(activatedFrom.getPunishments().last().activatedByChargeNumber).isNull()
     }
-
-    @Test
-    fun `delete outcome restores activated from punishments`() {
-      val outcomeServiceV2 = OutcomeService(
-        2,
-        reportedAdjudicationRepository,
-        offenceCodeLookupService,
-        authenticationFacade,
-      )
-
-      val currentCharge = entityBuilder.reportedAdjudication(chargeNumber = "12345").also {
-        it.status = ReportedAdjudicationStatus.CHARGE_PROVED
-        it.addOutcome(
-          Outcome(id = 1, code = OutcomeCode.CHARGE_PROVED, actualCreatedDate = LocalDateTime.now()),
-        )
-      }
-
-      val reportToActivateFrom = entityBuilder.reportedAdjudication(chargeNumber = "activated").also {
-        it.clearPunishments()
-        it.addPunishment(
-          Punishment(
-            id = 1,
-            type = PunishmentType.ADDITIONAL_DAYS,
-            suspendedUntil = null,
-            activatedByChargeNumber = currentCharge.chargeNumber,
-            schedule =
-            mutableListOf(
-              PunishmentSchedule(id = 1, days = 10, suspendedUntil = LocalDate.now())
-                .also { s -> s.createDateTime = LocalDateTime.now() },
-              PunishmentSchedule(id = 2, days = 10, startDate = LocalDate.now(), endDate = LocalDate.now())
-                .also { s -> s.createDateTime = LocalDateTime.now().plusDays(1) },
-            ),
-          ),
-        )
-      }
-      whenever(reportedAdjudicationRepository.findByChargeNumber("12345")).thenReturn(currentCharge)
-      whenever(reportedAdjudicationRepository.findByPunishmentsActivatedByChargeNumber("12345")).thenReturn(
-        listOf(reportToActivateFrom),
-      )
-      whenever(reportedAdjudicationRepository.save(any())).thenReturn(currentCharge)
-
-      val response = outcomeServiceV2.deleteOutcome(chargeNumber = currentCharge.chargeNumber, id = 1)
-
-      val ada = reportToActivateFrom.getPunishments().first { it.id == 1L }
-      assertThat(ada.suspendedUntil).isEqualTo(LocalDate.now())
-      assertThat(ada.activatedByChargeNumber).isNull()
-      assertThat(ada.schedule.latestSchedule().startDate).isNull()
-      assertThat(ada.schedule.latestSchedule().endDate).isNull()
-      assertThat(ada.schedule.latestSchedule().suspendedUntil).isEqualTo(LocalDate.now())
-
-      assertThat(response.suspendedPunishmentEvents!!.size).isEqualTo(1)
-      assertThat(response.suspendedPunishmentEvents!!.first()).isEqualTo(
-        SuspendedPunishmentEvent(chargeNumber = reportToActivateFrom.chargeNumber, agencyId = reportToActivateFrom.originatingAgencyId, status = reportToActivateFrom.status),
-      )
-    }
   }
 
   @Nested
@@ -1161,6 +1107,89 @@ class OutcomeServiceTest : ReportedAdjudicationTestBase() {
       assertThat(argumentCaptor.value.getOutcomes().first().quashedReason).isNull()
 
       assertThat(response).isNotNull
+    }
+  }
+
+  @Nested
+  inner class Deactivations {
+
+    private fun currentChargeForActivation() = entityBuilder.reportedAdjudication(chargeNumber = "12345").also {
+      it.status = ReportedAdjudicationStatus.CHARGE_PROVED
+      it.addOutcome(
+        Outcome(id = 1, code = OutcomeCode.CHARGE_PROVED, actualCreatedDate = LocalDateTime.now()),
+      )
+    }
+
+    private fun reportToActivateFrom(chargeNumber: String) = entityBuilder.reportedAdjudication(chargeNumber = "activated").also {
+      it.clearPunishments()
+      it.addPunishment(
+        Punishment(
+          id = 1,
+          type = PunishmentType.ADDITIONAL_DAYS,
+          suspendedUntil = null,
+          activatedByChargeNumber = chargeNumber,
+          schedule =
+          mutableListOf(
+            PunishmentSchedule(id = 1, days = 10, suspendedUntil = LocalDate.now())
+              .also { s -> s.createDateTime = LocalDateTime.now() },
+            PunishmentSchedule(id = 2, days = 10, startDate = LocalDate.now(), endDate = LocalDate.now())
+              .also { s -> s.createDateTime = LocalDateTime.now().plusDays(1) },
+          ),
+        ),
+      )
+    }
+
+    private fun assertDeactivation(response: ReportedAdjudicationDto, report: ReportedAdjudication) {
+      val ada = report.getPunishments().first { it.id == 1L }
+      assertThat(ada.suspendedUntil).isEqualTo(LocalDate.now())
+      assertThat(ada.activatedByChargeNumber).isNull()
+      assertThat(ada.schedule.latestSchedule().startDate).isNull()
+      assertThat(ada.schedule.latestSchedule().endDate).isNull()
+      assertThat(ada.schedule.latestSchedule().suspendedUntil).isEqualTo(LocalDate.now())
+
+      assertThat(response.suspendedPunishmentEvents!!.size).isEqualTo(1)
+      assertThat(response.suspendedPunishmentEvents!!.first()).isEqualTo(
+        SuspendedPunishmentEvent(chargeNumber = report.chargeNumber, agencyId = report.originatingAgencyId, status = report.status),
+      )
+    }
+
+    @Test
+    fun `quash outcome deactivates activated suspended from punishments`() {
+      val outcomeServiceV2 = OutcomeService(
+        2,
+        reportedAdjudicationRepository,
+        offenceCodeLookupService,
+        authenticationFacade,
+      )
+
+      val currentCharge = currentChargeForActivation()
+      val reportToTest = reportToActivateFrom(currentCharge.chargeNumber)
+      whenever(reportedAdjudicationRepository.findByChargeNumber("12345")).thenReturn(currentCharge)
+      whenever(reportedAdjudicationRepository.findByPunishmentsActivatedByChargeNumber("12345")).thenReturn(
+        listOf(reportToTest),
+      )
+      whenever(reportedAdjudicationRepository.save(any())).thenReturn(currentCharge)
+
+      assertDeactivation(outcomeServiceV2.createQuashed(chargeNumber = currentCharge.chargeNumber, reason = QuashedReason.OTHER, details = ""), reportToTest)
+    }
+
+    @Test
+    fun `delete outcome deactivates activated suspended from punishments`() {
+      val outcomeServiceV2 = OutcomeService(
+        2,
+        reportedAdjudicationRepository,
+        offenceCodeLookupService,
+        authenticationFacade,
+      )
+
+      val currentCharge = currentChargeForActivation()
+      val reportToTest = reportToActivateFrom(currentCharge.chargeNumber)
+      whenever(reportedAdjudicationRepository.findByChargeNumber("12345")).thenReturn(currentCharge)
+      whenever(reportedAdjudicationRepository.findByPunishmentsActivatedByChargeNumber("12345")).thenReturn(
+        listOf(reportToTest),
+      )
+      whenever(reportedAdjudicationRepository.save(any())).thenReturn(currentCharge)
+      assertDeactivation(outcomeServiceV2.deleteOutcome(chargeNumber = currentCharge.chargeNumber, id = 1), reportToTest)
     }
   }
 }


### PR DESCRIPTION
Unquashed will not attempt to restore, as it no longer has the relevant links.  Additionally, as the process takes so long (and only occurred 3 times in prod) the data would be out of date.

Confirmed with John in the event of this, the user would need to reapply any activated punishments in the event this occurred.