### PR TITLE
ADJST-1054 Migration of charge proved records.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/ScheduleTaskController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/ScheduleTaskController.kt
@@ -3,8 +3,10 @@ package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.TransferMigrationService
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.draft.DraftAdjudicationService
 
 @RestController
@@ -13,9 +15,24 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.draft.D
 @RequestMapping("/scheduled-tasks")
 class ScheduleTaskController(
   private val draftAdjudicationService: DraftAdjudicationService,
+  private val transferMigrationService: TransferMigrationService,
 ) {
 
   @DeleteMapping(value = ["/delete-orphaned-draft-adjudications"])
   fun deleteOrphanedDraftAdjudications(): Unit =
     draftAdjudicationService.deleteOrphanedDraftAdjudications()
+
+  @PostMapping("/migration-populate-charges")
+  fun populateChargesToMigrate(): Unit =
+    transferMigrationService.setupChargeIds()
+
+  @PostMapping("/migration-process-charges")
+  fun processCharges() {
+    var record = transferMigrationService.getNextRecord()
+    while (record != null) {
+      transferMigrationService.processRecord(record.chargeNumber)
+      transferMigrationService.completeProcessing(record.chargeNumber)
+      record = transferMigrationService.getNextRecord()
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/TransferMigrationCharges.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/TransferMigrationCharges.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities
+
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import org.hibernate.validator.constraints.Length
+
+@Entity
+class TransferMigrationCharges(
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val id: Long? = null,
+  @field:Length(max = 16)
+  var chargeNumber: String,
+  @Enumerated(EnumType.STRING)
+  var status: TransferMigrationChargeStatus,
+)
+
+enum class TransferMigrationChargeStatus {
+  READY,
+  PROCESSING,
+  COMPLETE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepository.kt
@@ -118,6 +118,14 @@ interface ReportedAdjudicationRepository : CrudRepository<ReportedAdjudication, 
   fun findByPunishmentsActivatedByChargeNumber(chargeNumber: String): List<ReportedAdjudication>
 
   @Query(
+    value = "select charge_number from reported_adjudications ra where ra.status in :statuses",
+    nativeQuery = true,
+  )
+  fun findChargeNumbersByStatus(
+    @Param("statuses") statuses: List<String>,
+  ): List<String>
+
+  @Query(
     value = "select count(1) from reported_adjudications ra where ra.status in :statuses $TRANSFER_IN",
     nativeQuery = true,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/TransferMigrationChargesRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/TransferMigrationChargesRepository.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories
+
+import org.springframework.data.repository.CrudRepository
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.TransferMigrationChargeStatus
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.TransferMigrationCharges
+
+interface TransferMigrationChargesRepository : CrudRepository<TransferMigrationCharges, Long> {
+
+  fun findFirstByStatus(status: TransferMigrationChargeStatus): TransferMigrationCharges?
+  fun findByChargeNumber(chargeNumber: String): TransferMigrationCharges?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/PrisonerSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/PrisonerSearchService.kt
@@ -13,6 +13,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 data class PrisonerResponse(
   val firstName: String,
   val lastName: String,
+  val prisonId: String = "",
 )
 
 @Service

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/TransferMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/TransferMigrationService.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.TransferMigrationChargeStatus
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.TransferMigrationCharges
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.TransferMigrationChargesRepository
+
+@Transactional
+@Service
+class TransferMigrationService(
+  private val reportedAdjudicationRepository: ReportedAdjudicationRepository,
+  private val transferMigrationChargeRepository: TransferMigrationChargesRepository,
+  private val prisonerSearchService: PrisonerSearchService,
+) {
+
+  fun processRecord(chargeNumber: String) {
+    val adjudication = reportedAdjudicationRepository.findByChargeNumber(chargeNumber)!!
+    val prisoner = prisonerSearchService.getPrisonerDetail(adjudication.prisonerNumber)!!
+
+    adjudication.overrideAgencyId = prisoner.prisonId
+  }
+
+  fun completeProcessing(chargeNumber: String) {
+    val record = transferMigrationChargeRepository.findByChargeNumber(chargeNumber) ?: return
+    record.status = TransferMigrationChargeStatus.COMPLETE
+  }
+
+  fun getNextRecord(): TransferMigrationCharges? {
+    val record = transferMigrationChargeRepository.findFirstByStatus(TransferMigrationChargeStatus.READY)
+    record?.let { it.status = TransferMigrationChargeStatus.PROCESSING }
+    return record
+  }
+
+  fun setupChargeIds() {
+    val chargeIds = reportedAdjudicationRepository.findChargeNumbersByStatus(listOf(ReportedAdjudicationStatus.CHARGE_PROVED.name))
+    transferMigrationChargeRepository.saveAll(
+      chargeIds.map {
+        TransferMigrationCharges(chargeNumber = it, status = TransferMigrationChargeStatus.READY)
+      },
+    )
+  }
+}

--- a/src/main/resources/db/migration/V123__transfer_migration_table.sql
+++ b/src/main/resources/db/migration/V123__transfer_migration_table.sql
@@ -1,0 +1,7 @@
+
+create table transfer_migration_charges
+(
+    id                 serial primary key,
+    charge_number      varchar(255),
+    status             varchar(255)
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/SqsIntegrationTestBase.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration
 
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
@@ -16,7 +15,6 @@ import uk.gov.justice.hmpps.sqs.MissingQueueException
 import uk.gov.justice.hmpps.sqs.MissingTopicException
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class SqsIntegrationTestBase : IntegrationTestBase() {
 
   @Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/TransferMigrationServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/TransferMigrationServiceIntTest.kt
@@ -1,0 +1,77 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.config.TestOAuth2Config
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.TransferMigrationChargeStatus
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration.IntegrationTestData.Companion.DEFAULT_REPORTED_DATE_TIME
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.TransferMigrationChargesRepository
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.PrisonerResponse
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.PrisonerSearchService
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Import(TestOAuth2Config::class)
+@ActiveProfiles("test")
+class TransferMigrationServiceIntTest : SqsIntegrationTestBase() {
+
+  @Autowired
+  private lateinit var transferMigrationChargesRepository: TransferMigrationChargesRepository
+
+  @Autowired
+  private lateinit var reportedAdjudicationRepository: ReportedAdjudicationRepository
+
+  @MockitoBean
+  lateinit var prisonerSearchService: PrisonerSearchService
+
+  @BeforeEach
+  fun setUp() {
+    setAuditTime(DEFAULT_REPORTED_DATE_TIME)
+  }
+
+  fun setContentHeader(
+    contentType: MediaType = MediaType.APPLICATION_JSON,
+  ): (HttpHeaders) -> Unit = {
+    it.contentType = contentType
+  }
+
+  @Test
+  fun `Populate charges and process migration`() {
+    val testData = IntegrationTestData.getDefaultAdjudication(offenderBookingId = 1000)
+    val scenario = initDataForUnScheduled(testData = testData).createHearing(dateTimeOfHearing = LocalDateTime.now().plusDays(1)).createChargeProved().createPunishments(
+      startDate = LocalDate.now().plusDays(1),
+    )
+    whenever(prisonerSearchService.getPrisonerDetail(any())).thenReturn(PrisonerResponse("Bob", "Smith", "PSI"))
+
+    webTestClient.post()
+      .uri("/scheduled-tasks/migration-populate-charges")
+      .headers(setContentHeader())
+      .exchange()
+      .expectStatus().is2xxSuccessful
+
+    var charges = transferMigrationChargesRepository.findAll()
+    assertThat(charges.toList().all { it.status == TransferMigrationChargeStatus.READY }).isTrue()
+
+    webTestClient.post()
+      .uri("/scheduled-tasks/migration-process-charges")
+      .headers(setContentHeader())
+      .exchange()
+      .expectStatus().is2xxSuccessful
+
+    charges = transferMigrationChargesRepository.findAll()
+    assertThat(charges.toList().all { it.status == TransferMigrationChargeStatus.COMPLETE }).isTrue()
+
+    val charge = reportedAdjudicationRepository.findByChargeNumber(scenario.getGeneratedChargeNumber())
+    assertThat(charge!!.overrideAgencyId).isEqualTo("PSI")
+  }
+}


### PR DESCRIPTION
This is the migration path for setting the `overrideAgencyId` for all existing `CHARGE_PROVED` adjudications.

I'll run a db script to populate the table which is tracking the migration and monitor as it goes. Its currently going to be a long running request which will migrate each charge, I can run this request a few times so its multi-threaded and even spread over pods. 

Firstly I'll test on dev to make sure this is viable. 