### PR TITLE
MAP-2120: Temporary job to update location UUID based on the existing location ID

### DIFF
--- a/helm_deploy/hmpps-manage-adjudications-api/templates/fix-adjudications-locations-cronjob.yaml
+++ b/helm_deploy/hmpps-manage-adjudications-api/templates/fix-adjudications-locations-cronjob.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: fix-adjudications-locations
+spec:
+  schedule:  "{{ .Values.cron.fixAdjudicationsLocations }}"
+  concurrencyPolicy: Replace
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 43200
+  successfulJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 345600 # 4 days
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: Never
+          activeDeadlineSeconds: 3600
+          containers:
+            - name: fix-adjudications-locations-job
+              image: ghcr.io/ministryofjustice/hmpps-devops-tools
+              args:
+                - /bin/sh
+                - -c
+                - curl --fail --retry 2 -XPOST http://hmpps-manage-adjudications-api/job/adjudications-fix-locations

--- a/helm_deploy/hmpps-manage-adjudications-api/values.yaml
+++ b/helm_deploy/hmpps-manage-adjudications-api/values.yaml
@@ -71,3 +71,6 @@ generic-prometheus-alerts:
   targetApplication: hmpps-manage-adjudications-api
   sqsAlertsOldestThreshold: 10
   sqsAlertsTotalMessagesThreshold: 1
+
+cron:
+  fixAdjudicationsLocations: "10 10 15 3 *"

--- a/helm_deploy/hmpps-manage-adjudications-api/values.yaml
+++ b/helm_deploy/hmpps-manage-adjudications-api/values.yaml
@@ -18,7 +18,11 @@ generic-service:
     annotations:
       # Secure the all scheduled task endpoints from outside the Kubernetes ingress
       nginx.ingress.kubernetes.io/server-snippet: |
-        server_tokens off;
+        server_tokens off; 
+        location /job/ {
+          deny all;
+          return 401;
+        }
         location /scheduled-tasks/ {
           deny all;
           return 401;

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -35,4 +35,7 @@ generic-prometheus-alerts:
     - "dps-core-dev-prisoner-event-queue"
     - "dps-core-dev-prisoner-event-dlq"
 
+cron:
+  fixAdjudicationsLocations: "10 10 15 4 *"
+
 environment: dev

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -36,6 +36,6 @@ generic-prometheus-alerts:
     - "dps-core-dev-prisoner-event-dlq"
 
 cron:
-  fixAdjudicationsLocations: "10 10 15 4 *"
+  fixAdjudicationsLocations: "30 16 15 4 *"
 
 environment: dev

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -26,4 +26,7 @@ generic-prometheus-alerts:
     - "dps-core-preprod-prisoner-event-queue"
     - "dps-core-preprod-prisoner-event-dlq"
 
+cron:
+  fixAdjudicationsLocations: "00 09 16 4 *"
+
 environment: preprod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -39,4 +39,7 @@ generic-prometheus-alerts:
     - "dps-core-prod-prisoner-event-queue"
     - "dps-core-prod-prisoner-event-dlq"
 
+cron:
+  fixAdjudicationsLocations: "00 09 17 4 *"
+
 environment: prod

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/config/ResourceServerConfiguration.kt
@@ -58,7 +58,7 @@ class ResourceServerConfiguration {
           "/swagger-resources/configuration/security",
           "/scheduled-tasks/*",
           "/queue-admin/retry-all-dlqs",
-          "/job/**"
+          "/job/**",
         ).forEach { authorize(it, permitAll) }
         authorize(anyRequest, authenticated)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/config/ResourceServerConfiguration.kt
@@ -58,6 +58,7 @@ class ResourceServerConfiguration {
           "/swagger-resources/configuration/security",
           "/scheduled-tasks/*",
           "/queue-admin/retry-all-dlqs",
+          "/job/**"
         ).forEach { authorize(it, permitAll) }
         authorize(anyRequest, authenticated)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/ControllerAnnotations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/ControllerAnnotations.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class ProtectedByIngress
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class PublicEndpoint

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/JobTriggerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/JobTriggerController.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.job.FixLocations
 import java.time.Clock
 
 @RestController
-// @ProtectedByIngress
+@ProtectedByIngress
 @RequestMapping("/job", produces = [MediaType.TEXT_PLAIN_VALUE])
 class JobTriggerController(
   private val fixLocationsJob: FixLocationsJob,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/JobTriggerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/JobTriggerController.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers
+
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.job.FixLocationsJob
+import java.time.Clock
+
+@RestController
+// @ProtectedByIngress
+@RequestMapping("/job", produces = [MediaType.TEXT_PLAIN_VALUE])
+class JobTriggerController(
+  private val fixLocationsJob: FixLocationsJob,
+  private val clock: Clock,
+) {
+
+  @PostMapping(value = ["/adjudications-fix-locations"])
+  @Operation(
+    summary = "Trigger the job to fix locations uuids",
+    description = "",
+  )
+  @ResponseBody
+  @ResponseStatus(HttpStatus.CREATED)
+  fun triggerFixLocationsJob(): String {
+    fixLocationsJob.execute()
+    return "Fix locations data"
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/job/FixLocationsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/job/FixLocationsJob.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.job
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.FixLocationsService
+
+@Component
+class FixLocationsJob(
+  private val fixLocationsService: FixLocationsService,
+) {
+
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Async("asyncExecutor")
+  fun execute() {
+    log.info("executing fix location job")
+    fixLocationsService.fixIncidentDetailsLocations()
+    fixLocationsService.fixReportedAdjudicationLocations()
+    fixLocationsService.fixHearingLocations()
+    log.info("executing fix location job complete")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/LocationFixRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/LocationFixRepository.kt
@@ -13,12 +13,38 @@ interface LocationFixRepository : Repository<IncidentDetails, Long> {
     value = "select distinct id.location_id from incident_details id where id.location_id is not null and id.location_uuid is null",
     nativeQuery = true,
   )
-  fun findNomisLocationsIds(): List<Long>
+  fun findNomisIncidentDetailsLocationsIds(): List<Long>
 
   @Query(
     value = "update incident_details set location_uuid = :locationUuid where location_id = :locationId",
     nativeQuery = true,
   )
   @Modifying
-  fun updateLocationDetails(@Param("locationId") locationId: Long, @Param("locationUuid") locationUuid: UUID)
+  fun updateIncidentDetailsLocationIdDetails(@Param("locationId") locationId: Long, @Param("locationUuid") locationUuid: UUID)
+
+  @Query(
+    value = "select distinct ra.location_id from reported_adjudications ra where ra.location_id is not null and ra.location_uuid is null",
+    nativeQuery = true,
+  )
+  fun findNomisReportedAdjudicationsLocationsIds(): List<Long>
+
+  @Query(
+    value = "update reported_adjudications set location_uuid = :locationUuid where location_id = :locationId",
+    nativeQuery = true,
+  )
+  @Modifying
+  fun updateReportedAdjudicationsLocationsIdDetails(@Param("locationId") locationId: Long, @Param("locationUuid") locationUuid: UUID)
+
+  @Query(
+    value = "select distinct h.location_id from hearing h where h.location_id is not null and h.location_uuid is null",
+    nativeQuery = true,
+  )
+  fun findNomisHearingsLocationsIds(): List<Long>
+
+  @Query(
+    value = "update hearing set location_uuid = :locationUuid where location_id = :locationId",
+    nativeQuery = true,
+  )
+  @Modifying
+  fun updateHearingsLocationIdDetails(@Param("locationId") locationId: Long, @Param("locationUuid") locationUuid: UUID)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/LocationFixRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/LocationFixRepository.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories
+
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.Repository
+import org.springframework.data.repository.query.Param
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.IncidentDetails
+import java.util.UUID
+
+interface LocationFixRepository : Repository<IncidentDetails, Long> {
+
+  @Query(
+    value = "select distinct id.location_id from incident_details id where id.location_id is not null and id.location_uuid is null",
+    nativeQuery = true,
+  )
+  fun findNomisLocationsIds(): List<Long>
+
+  @Query(
+    value = "update incident_details set location_uuid = :locationUuid where location_id = :locationId",
+    nativeQuery = true,
+  )
+  @Modifying
+  fun updateLocationDetails(@Param("locationId") locationId: Long, @Param("locationUuid") locationUuid: UUID)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/FixLocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/FixLocationsService.kt
@@ -23,17 +23,19 @@ class FixLocationsService(
     val nomisLocationIds = locationFixRepository.findNomisIncidentDetailsLocationsIds()
     var updateCount: Int = 0
 
-    nomisLocationIds.forEach { nomisLocationId ->
+    nomisLocationIds.mapNotNull { nomisLocationId ->
       try {
-        val dpsId = locationService.getNomisLocationDetail(nomisLocationId.toString())!!.dpsLocationId
-        locationFixRepository.updateIncidentDetailsLocationIdDetails(
-          locationId = nomisLocationId,
-          locationUuid = UUID.fromString(dpsId)
-        )
-        updateCount++
+        nomisLocationId to locationService.getNomisLocationDetail(nomisLocationId.toString())!!.dpsLocationId
       } catch (e: Exception) {
         log.warn("Failed to find DPS location UUID for Incident detail location ID: $nomisLocationId", e)
+        null
       }
+    }.forEach { (nomisLocationId, dpsId) ->
+      locationFixRepository.updateIncidentDetailsLocationIdDetails(
+        locationId = nomisLocationId,
+        locationUuid = UUID.fromString(dpsId)
+      )
+      updateCount++
     }
     log.info("Updated $updateCount of ${nomisLocationIds.size} distinct incident detail location Ids")
   }
@@ -42,17 +44,19 @@ class FixLocationsService(
     // look up location ids for reported adjudications
     val reportedAdjudicationsIds = locationFixRepository.findNomisReportedAdjudicationsLocationsIds()
     var updateCount: Int = 0
-    reportedAdjudicationsIds.forEach { reportedAdjudicationsId ->
+    reportedAdjudicationsIds.mapNotNull { reportedAdjudicationsId ->
       try {
-        val dpsId = locationService.getNomisLocationDetail(reportedAdjudicationsId.toString())!!.dpsLocationId
-        locationFixRepository.updateReportedAdjudicationsLocationsIdDetails(
-          locationId = reportedAdjudicationsId,
-          locationUuid = UUID.fromString(dpsId)
-        )
-        updateCount++
+        reportedAdjudicationsId to locationService.getNomisLocationDetail(reportedAdjudicationsId.toString())!!.dpsLocationId
       } catch (e: Exception) {
         log.warn("Failed to find DPS location UUID for Reported Adjudication location ID: $reportedAdjudicationsId", e)
+        null
       }
+    }.forEach { (reportedAdjudicationsId, dpsId ) ->
+      locationFixRepository.updateReportedAdjudicationsLocationsIdDetails(
+        locationId = reportedAdjudicationsId,
+        locationUuid = UUID.fromString(dpsId)
+      )
+      updateCount++
     }
     log.info("Updated $updateCount of ${reportedAdjudicationsIds.size} distinct reported adjudication location Ids")
   }
@@ -61,14 +65,16 @@ class FixLocationsService(
     // look up location ids for hearings
     val hearingIds = locationFixRepository.findNomisHearingsLocationsIds()
     var updateCount: Int = 0
-    hearingIds.forEach { hearingId ->
+    hearingIds.mapNotNull { hearingId ->
       try {
-        val dpsId = locationService.getNomisLocationDetail(hearingId.toString())!!.dpsLocationId
-        locationFixRepository.updateHearingsLocationIdDetails(locationId = hearingId, locationUuid = UUID.fromString(dpsId))
-        updateCount++
+        hearingId to locationService.getNomisLocationDetail(hearingId.toString())!!.dpsLocationId
       } catch (e: Exception) {
         log.warn("Failed to find DPS location UUID for hearing location ID: $hearingId", e)
+        null
       }
+    }.forEach { (hearingId, dpsId) ->
+      locationFixRepository.updateHearingsLocationIdDetails(locationId = hearingId, locationUuid = UUID.fromString(dpsId))
+      updateCount++
     }
     log.info("Updated $updateCount of ${hearingIds.size} distinct hearing location Ids")
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/FixLocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/FixLocationsService.kt
@@ -21,32 +21,55 @@ class FixLocationsService(
   fun fixIncidentDetailsLocations() {
     // look up location ids
     val nomisLocationIds = locationFixRepository.findNomisIncidentDetailsLocationsIds()
+    var updateCount: Int = 0
 
     nomisLocationIds.forEach { nomisLocationId ->
-      // get the dps location id
-      val dpsId = locationService.getNomisLocationDetail(nomisLocationId.toString())!!.dpsLocationId
-      locationFixRepository.updateIncidentDetailsLocationIdDetails(locationId = nomisLocationId, locationUuid = UUID.fromString(dpsId))
+      try {
+        val dpsId = locationService.getNomisLocationDetail(nomisLocationId.toString())!!.dpsLocationId
+        locationFixRepository.updateIncidentDetailsLocationIdDetails(
+          locationId = nomisLocationId,
+          locationUuid = UUID.fromString(dpsId)
+        )
+        updateCount++
+      } catch (e: Exception) {
+        log.warn("Failed to find DPS location UUID for Incident detail location ID: $nomisLocationId", e)
+      }
     }
+    log.info("Updated $updateCount of ${nomisLocationIds.size} distinct incident detail location Ids")
   }
 
   fun fixReportedAdjudicationLocations() {
-    // look up location ids for adjudications
+    // look up location ids for reported adjudications
     val reportedAdjudicationsIds = locationFixRepository.findNomisReportedAdjudicationsLocationsIds()
-
-    // loop through
+    var updateCount: Int = 0
     reportedAdjudicationsIds.forEach { reportedAdjudicationsId ->
-      val dpsId = locationService.getNomisLocationDetail(reportedAdjudicationsId.toString())!!.dpsLocationId
-      locationFixRepository.updateReportedAdjudicationsLocationsIdDetails(locationId = reportedAdjudicationsId, locationUuid = UUID.fromString(dpsId))
+      try {
+        val dpsId = locationService.getNomisLocationDetail(reportedAdjudicationsId.toString())!!.dpsLocationId
+        locationFixRepository.updateReportedAdjudicationsLocationsIdDetails(
+          locationId = reportedAdjudicationsId,
+          locationUuid = UUID.fromString(dpsId)
+        )
+        updateCount++
+      } catch (e: Exception) {
+        log.warn("Failed to find DPS location UUID for Reported Adjudication location ID: $reportedAdjudicationsId", e)
+      }
     }
+    log.info("Updated $updateCount of ${reportedAdjudicationsIds.size} distinct reported adjudication location Ids")
   }
 
   fun fixHearingLocations() {
     // look up location ids for hearings
     val hearingIds = locationFixRepository.findNomisHearingsLocationsIds()
-    // loop through
+    var updateCount: Int = 0
     hearingIds.forEach { hearingId ->
-      val dpsId = locationService.getNomisLocationDetail(hearingId.toString())!!.dpsLocationId
-      locationFixRepository.updateHearingsLocationIdDetails(locationId = hearingId, locationUuid = UUID.fromString(dpsId))
+      try {
+        val dpsId = locationService.getNomisLocationDetail(hearingId.toString())!!.dpsLocationId
+        locationFixRepository.updateHearingsLocationIdDetails(locationId = hearingId, locationUuid = UUID.fromString(dpsId))
+        updateCount++
+      } catch (e: Exception) {
+        log.warn("Failed to find DPS location UUID for hearing location ID: $hearingId", e)
+      }
     }
+    log.info("Updated $updateCount of ${hearingIds.size} distinct hearing location Ids")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/FixLocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/FixLocationsService.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.LocationFixRepository
+import java.util.UUID
+
+@Transactional
+@Service
+class FixLocationsService(
+  private val locationService: LocationService,
+  private val locationFixRepository: LocationFixRepository,
+) {
+
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun fixIncidentDetailsLocations() {
+    // look up location ids
+    val nomisLocationIds = locationFixRepository.findNomisLocationsIds()
+
+    nomisLocationIds.forEach { nomisLocationId ->
+      // get the dps location id
+      val dpsId = locationService.getNomisLocationDetail(nomisLocationId.toString())!!.dpsLocationId
+      locationFixRepository.updateLocationDetails(locationId = nomisLocationId, locationUuid = UUID.fromString(dpsId))
+    }
+  }
+
+  fun fixReportedAdjudicationLocations() {
+    // look up location ids for adjudications
+
+    // loop through
+
+    // get the dps location id
+    // val dpsId = locationService.getNomisLocationDetail("1234")?.dpsLocationId
+
+    // update entities
+  }
+
+  fun fixHearingLocations() {
+    // look up location ids for hearings
+
+    // loop through
+
+    // get the dps location id
+    // val dpsId = locationService.getNomisLocationDetail("1234")?.dpsLocationId
+
+    // update entities
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/FixLocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/FixLocationsService.kt
@@ -20,34 +20,33 @@ class FixLocationsService(
 
   fun fixIncidentDetailsLocations() {
     // look up location ids
-    val nomisLocationIds = locationFixRepository.findNomisLocationsIds()
+    val nomisLocationIds = locationFixRepository.findNomisIncidentDetailsLocationsIds()
 
     nomisLocationIds.forEach { nomisLocationId ->
       // get the dps location id
       val dpsId = locationService.getNomisLocationDetail(nomisLocationId.toString())!!.dpsLocationId
-      locationFixRepository.updateLocationDetails(locationId = nomisLocationId, locationUuid = UUID.fromString(dpsId))
+      locationFixRepository.updateIncidentDetailsLocationIdDetails(locationId = nomisLocationId, locationUuid = UUID.fromString(dpsId))
     }
   }
 
   fun fixReportedAdjudicationLocations() {
     // look up location ids for adjudications
+    val reportedAdjudicationsIds = locationFixRepository.findNomisReportedAdjudicationsLocationsIds()
 
     // loop through
-
-    // get the dps location id
-    // val dpsId = locationService.getNomisLocationDetail("1234")?.dpsLocationId
-
-    // update entities
+    reportedAdjudicationsIds.forEach { reportedAdjudicationsId ->
+      val dpsId = locationService.getNomisLocationDetail(reportedAdjudicationsId.toString())!!.dpsLocationId
+      locationFixRepository.updateReportedAdjudicationsLocationsIdDetails(locationId = reportedAdjudicationsId, locationUuid = UUID.fromString(dpsId))
+    }
   }
 
   fun fixHearingLocations() {
     // look up location ids for hearings
-
+    val hearingIds = locationFixRepository.findNomisHearingsLocationsIds()
     // loop through
-
-    // get the dps location id
-    // val dpsId = locationService.getNomisLocationDetail("1234")?.dpsLocationId
-
-    // update entities
+    hearingIds.forEach { hearingId ->
+      val dpsId = locationService.getNomisLocationDetail(hearingId.toString())!!.dpsLocationId
+      locationFixRepository.updateHearingsLocationIdDetails(locationId = hearingId, locationUuid = UUID.fromString(dpsId))
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/FixLocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/FixLocationsService.kt
@@ -33,7 +33,7 @@ class FixLocationsService(
     }.forEach { (nomisLocationId, dpsId) ->
       locationFixRepository.updateIncidentDetailsLocationIdDetails(
         locationId = nomisLocationId,
-        locationUuid = UUID.fromString(dpsId)
+        locationUuid = UUID.fromString(dpsId),
       )
       updateCount++
     }
@@ -51,10 +51,10 @@ class FixLocationsService(
         log.warn("Failed to find DPS location UUID for Reported Adjudication location ID: $reportedAdjudicationsId", e)
         null
       }
-    }.forEach { (reportedAdjudicationsId, dpsId ) ->
+    }.forEach { (reportedAdjudicationsId, dpsId) ->
       locationFixRepository.updateReportedAdjudicationsLocationsIdDetails(
         locationId = reportedAdjudicationsId,
-        locationUuid = UUID.fromString(dpsId)
+        locationUuid = UUID.fromString(dpsId),
       )
       updateCount++
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/FixLocationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/FixLocationIntTest.kt
@@ -1,0 +1,260 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration
+
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.draft.DraftAdjudicationResponse
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.reported.ReportedAdjudicationResponse
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.ReportedAdjudicationDto
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeAdjournReason
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomePlea
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OicHearingType
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.LocationResponse
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.LocationService
+import java.time.LocalDateTime
+import java.util.UUID
+
+class FixLocationIntTest : SqsIntegrationTestBase() {
+
+  @MockitoBean
+  private lateinit var locationService: LocationService
+
+  val uuid1 = UUID.fromString("11111111-1111-1111-1111-111111111111")
+  val uuid2 = UUID.fromString("22222222-2222-2222-2222-222222222222")
+  val uuid3 = UUID.fromString("33333333-3333-3333-3333-333333333333")
+  val uuid4 = UUID.fromString("44444444-4444-4444-4444-444444444444")
+
+  @BeforeEach
+  fun setUp() {
+    whenever(locationService.getNomisLocationDetail("12345"))
+      .thenReturn(LocationResponse("11111111-1111-1111-1111-111111111111", 12345))
+
+    whenever(locationService.getNomisLocationDetail("23456"))
+      .thenReturn(LocationResponse("22222222-2222-2222-2222-222222222222", 23456))
+
+    whenever(locationService.getNomisLocationDetail("34567"))
+      .thenReturn(LocationResponse("33333333-3333-3333-3333-333333333333", 34567))
+
+    whenever(locationService.getNomisLocationDetail("45678"))
+      .thenReturn(LocationResponse("44444444-4444-4444-4444-444444444444", 45678))
+  }
+
+  @Test
+  fun `run location job for updating incident details`() {
+    val draftId1 = createDraftAdjudication(12345)
+    val draftId2 = createDraftAdjudication(23456)
+    val draftId3 = createDraftAdjudication(34567)
+    val draftId4 = createDraftAdjudication(45678, uuid4)
+
+    runFixLocationJob()
+    Thread.sleep(1000)
+
+    assertIncidentDetailsLocationUuidUpdated(draftId = draftId1, locationId = 12345, locationUuid = uuid1)
+    assertIncidentDetailsLocationUuidUpdated(draftId = draftId2, locationId = 23456, locationUuid = uuid2)
+    assertIncidentDetailsLocationUuidUpdated(draftId = draftId3, locationId = 34567, locationUuid = uuid3)
+    assertIncidentDetailsLocationUuidUpdated(draftId = draftId4, locationId = 45678, locationUuid = uuid4)
+
+    verify(locationService, times(1)).getNomisLocationDetail(eq("12345"))
+    verify(locationService, times(1)).getNomisLocationDetail(eq("23456"))
+    verify(locationService, times(1)).getNomisLocationDetail(eq("34567"))
+    verifyNoMoreInteractions(locationService)
+  }
+
+  @Test
+  fun `run location job for updating reported adjudications`() {
+    val testAdjudication1 = IntegrationTestData.getDefaultAdjudication().copy(locationId = 12345, locationUuid = null)
+    val intTestData1 = integrationTestData()
+    val intTestBuilder1 = IntegrationTestScenarioBuilder(
+      intTestData = intTestData1,
+      intTestBase = this,
+      activeCaseload = testAdjudication1.agencyId,
+    )
+
+    intTestBuilder1
+      .startDraft(testAdjudication1)
+      .setApplicableRules()
+      .setIncidentRole()
+      .setOffenceData()
+      .addDamages()
+      .addIncidentStatement()
+      .completeDraft()
+      .acceptReport(activeCaseload = testAdjudication1.agencyId).issueReport()
+
+    val testAdjudication2 = IntegrationTestData.getDefaultAdjudication().copy(locationId = 23456, locationUuid = null)
+    val intTestData2 = integrationTestData()
+    val intTestBuilder2 = IntegrationTestScenarioBuilder(
+      intTestData = intTestData2,
+      intTestBase = this,
+      activeCaseload = testAdjudication2.agencyId,
+    )
+
+    intTestBuilder2
+      .startDraft(testAdjudication2)
+      .setApplicableRules()
+      .setIncidentRole()
+      .setOffenceData()
+      .addDamages()
+      .addIncidentStatement()
+      .completeDraft()
+      .acceptReport(activeCaseload = testAdjudication2.agencyId).issueReport()
+
+    runFixLocationJob()
+    Thread.sleep(1000)
+
+    val reportAdjudicationDto1: ReportedAdjudicationDto = getReportedAdjudication(testAdjudication1.chargeNumber!!)
+    val reportAdjudicationDto2: ReportedAdjudicationDto = getReportedAdjudication(testAdjudication2.chargeNumber!!)
+
+    assertEquals(12345L, reportAdjudicationDto1.incidentDetails.locationId)
+    assertEquals(uuid1, reportAdjudicationDto1.incidentDetails.locationUuid)
+
+    assertEquals(23456L, reportAdjudicationDto2.incidentDetails.locationId)
+    assertEquals(uuid2, reportAdjudicationDto2.incidentDetails.locationUuid)
+  }
+
+  @Test
+  fun `run location job for updating hearings`() {
+    val testData = IntegrationTestData.getDefaultAdjudication()
+    val scenario = initDataForUnScheduled(testData = testData)
+
+    val reportAdjudicationDto: ReportedAdjudicationDto = getReportedAdjudication(scenario.getGeneratedChargeNumber())
+
+    assertTrue(reportAdjudicationDto.hearings.isEmpty())
+
+    createHearingWithoutLocationUuid(
+      scenario.getGeneratedChargeNumber(),
+      12345,
+      LocalDateTime.of(2022, 1, 1, 1, 1, 1),
+    )
+    createHearingWithoutLocationUuid(
+      scenario.getGeneratedChargeNumber(),
+      23456,
+      LocalDateTime.of(2022, 1, 1, 2, 1, 1),
+    )
+
+    createHearingWithoutLocationUuid(
+      scenario.getGeneratedChargeNumber(),
+      34567,
+      LocalDateTime.of(2022, 1, 1, 3, 1, 1),
+    )
+
+    val reportAdjudicationDto1: ReportedAdjudicationDto = getReportedAdjudication(scenario.getGeneratedChargeNumber())
+
+    with(reportAdjudicationDto1.hearings) {
+      this.single { it.locationId == 12345L && it.locationUuid == null }
+      this.single { it.locationId == 23456L && it.locationUuid == null }
+      this.single { it.locationId == 34567L && it.locationUuid == null }
+    }
+
+    runFixLocationJob()
+    Thread.sleep(1000)
+
+    val reportAdjudicationDto2: ReportedAdjudicationDto = getReportedAdjudication(scenario.getGeneratedChargeNumber())
+
+    with(reportAdjudicationDto2.hearings) {
+      this.single { it.locationId == 12345L && it.locationUuid == uuid1 }
+      this.single { it.locationId == 23456L && it.locationUuid == uuid2 }
+      this.single { it.locationId == 34567L && it.locationUuid == uuid3 }
+    }
+  }
+
+  // FIXME test for multiple of the the same location (in existing tests, also ones already set maybe)
+
+  private fun runFixLocationJob() = webTestClient.post()
+    .uri("/job/adjudications-fix-locations")
+    .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))
+    .exchange()
+    .expectStatus().isCreated
+
+  private fun createDraftAdjudication(locationId: Long, locationUuid: UUID? = null): Long {
+    val draftAdjudicationResponse = webTestClient.post()
+      .uri("/draft-adjudications")
+      .headers(setHeaders())
+      .bodyValue(
+        mapOf(
+          "prisonerNumber" to "A12345",
+          "agencyId" to "MDI",
+          "locationId" to locationId,
+          "locationUuid" to locationUuid,
+          "dateTimeOfIncident" to LocalDateTime.of(2010, 10, 12, 10, 0),
+          "dateTimeOfDiscovery" to LocalDateTime.of(2010, 10, 12, 10, 0),
+          "isYouthOffenderRule" to false,
+        ),
+      )
+      .exchange()
+      .expectStatus().isCreated
+      .returnResult(DraftAdjudicationResponse::class.java)
+      .responseBody
+      .blockFirst()!!
+
+    assertEquals(locationId, draftAdjudicationResponse.draftAdjudication.incidentDetails.locationId)
+    assertEquals(locationUuid, draftAdjudicationResponse.draftAdjudication.incidentDetails.locationUuid)
+
+    return draftAdjudicationResponse.draftAdjudication.id
+  }
+
+  private fun createHearingWithoutLocationUuid(chargeNumber: String, locationId: Long, date: LocalDateTime) {
+    webTestClient.post()
+      .uri("/reported-adjudications/$chargeNumber/hearing/v2")
+      .headers(setHeaders())
+      .bodyValue(
+        mapOf(
+          "locationId" to locationId,
+          "dateTimeOfHearing" to date,
+          "oicHearingType" to OicHearingType.GOV.name,
+        ),
+      )
+      .exchange()
+      .expectStatus().isCreated
+      .returnResult(ReportedAdjudicationResponse::class.java)
+      .responseBody
+      .blockFirst()!!
+
+    webTestClient.post()
+      .uri("/reported-adjudications/$chargeNumber/hearing/outcome/adjourn")
+      .headers(setHeaders(username = "ITAG_ALO"))
+      .bodyValue(
+        mapOf(
+          "details" to "details",
+          "adjudicator" to "testing",
+          "reason" to HearingOutcomeAdjournReason.LEGAL_ADVICE,
+          "plea" to HearingOutcomePlea.UNFIT,
+        ),
+      )
+      .exchange()
+      .expectStatus().isCreated
+  }
+
+  private fun assertIncidentDetailsLocationUuidUpdated(draftId: Long, locationId: Long, locationUuid: UUID) {
+    val updatedLocationDraft = webTestClient.get()
+      .uri("/draft-adjudications/$draftId")
+      .headers(setHeaders(username = "username", activeCaseload = "MDI"))
+      .exchange()
+      .expectStatus().isOk
+      .returnResult(DraftAdjudicationResponse::class.java)
+      .responseBody
+      .blockFirst()!!
+
+    assertEquals(locationId, updatedLocationDraft.draftAdjudication.incidentDetails.locationId)
+    assertEquals(locationUuid, updatedLocationDraft.draftAdjudication.incidentDetails.locationUuid)
+  }
+
+  private fun getReportedAdjudication(chargeNumber: String): ReportedAdjudicationDto {
+    val reportedAdjudicationResponse = webTestClient.get()
+      .uri("/reported-adjudications/$chargeNumber/v2")
+      .headers(setHeaders(username = "username", activeCaseload = "MDI"))
+      .exchange()
+      .expectStatus().isOk
+      .returnResult(ReportedAdjudicationResponse::class.java)
+      .responseBody
+      .blockFirst()!!
+
+    return reportedAdjudicationResponse.reportedAdjudication
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/FixLocationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/FixLocationIntTest.kt
@@ -2,9 +2,11 @@ package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration
 
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -45,6 +47,12 @@ class FixLocationIntTest : SqsIntegrationTestBase() {
     whenever(locationService.getNomisLocationDetail("45678"))
       .thenReturn(LocationResponse("44444444-4444-4444-4444-444444444444", 45678))
   }
+
+  @AfterEach
+  fun tearDown() {
+    reset(locationService)
+  }
+
 
   @Test
   fun `run location job for updating incident details`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/FixLocationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/FixLocationIntTest.kt
@@ -202,8 +202,6 @@ class FixLocationIntTest : SqsIntegrationTestBase() {
     verifyNoMoreInteractions(locationService)
   }
 
-  // FIXME test for multiple of the the same location (in existing tests, also ones already set maybe)
-
   private fun runFixLocationJob() = webTestClient.post()
     .uri("/job/adjudications-fix-locations")
     .headers(setHeaders(username = "ITAG_ALO", roles = listOf("ROLE_ADJUDICATIONS_REVIEWER")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/FixLocationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/FixLocationIntTest.kt
@@ -9,7 +9,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers.draft.DraftAdjudicationResponse
@@ -53,7 +52,6 @@ class FixLocationIntTest : SqsIntegrationTestBase() {
     reset(locationService)
   }
 
-
   @Test
   fun `run location job for updating incident details`() {
     val draftId1 = createDraftAdjudication(12345)
@@ -72,7 +70,7 @@ class FixLocationIntTest : SqsIntegrationTestBase() {
     verify(locationService, times(1)).getNomisLocationDetail(eq("12345"))
     verify(locationService, times(1)).getNomisLocationDetail(eq("23456"))
     verify(locationService, times(1)).getNomisLocationDetail(eq("34567"))
-    verifyNoMoreInteractions(locationService)
+    verify(locationService, times(0)).getNomisLocationDetail(eq("45678"))
   }
 
   @Test
@@ -113,8 +111,6 @@ class FixLocationIntTest : SqsIntegrationTestBase() {
       .completeDraft()
       .acceptReport(activeCaseload = testAdjudication2.agencyId).issueReport()
 
-//    third
-
     val testAdjudication3 = IntegrationTestData.getDefaultAdjudication().copy(locationId = 34567, locationUuid = uuid3)
     val intTestData3 = integrationTestData()
     val intTestBuilder3 = IntegrationTestScenarioBuilder(
@@ -151,7 +147,7 @@ class FixLocationIntTest : SqsIntegrationTestBase() {
 
     verify(locationService, times(1)).getNomisLocationDetail(eq("12345"))
     verify(locationService, times(1)).getNomisLocationDetail(eq("23456"))
-    verifyNoMoreInteractions(locationService)
+    verify(locationService, times(0)).getNomisLocationDetail(eq("34567"))
   }
 
   @Test
@@ -207,7 +203,6 @@ class FixLocationIntTest : SqsIntegrationTestBase() {
     verify(locationService, times(1)).getNomisLocationDetail(eq("12345"))
     verify(locationService, times(1)).getNomisLocationDetail(eq("23456"))
     verify(locationService, times(1)).getNomisLocationDetail(eq("34567"))
-    verifyNoMoreInteractions(locationService)
   }
 
   private fun runFixLocationJob() = webTestClient.post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/IntegrationTestData.kt
@@ -236,6 +236,7 @@ class IntegrationTestData(
         "dateTimeOfIncident" to testDataSet.dateTimeOfIncident,
         "dateTimeOfDiscovery" to testDataSet.dateTimeOfDiscovery,
         "overrideAgencyId" to overrideAgencyId,
+        "locationUuid" to testDataSet.locationUuid,
       ),
     )
     .exchange()


### PR DESCRIPTION
In this PR we have set up a one off cron job to migrate the existing locationId to new UUID. This is part of the ticket: [MAP-2114](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?selectedIssue=MAP-2114)

[MAP-2114]: https://dsdmoj.atlassian.net/browse/MAP-2114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ