### PR TITLE
MAP-2120: change to update only one table and add one index. 

### DIFF
--- a/helm_deploy/hmpps-manage-adjudications-api/values.yaml
+++ b/helm_deploy/hmpps-manage-adjudications-api/values.yaml
@@ -6,6 +6,24 @@ generic-service:
 
   replicaCount: 4
 
+  livenessProbe:
+    httpGet:
+      path: /health/liveness
+      port: http
+    initialDelaySeconds: 300
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 10
+
+  readinessProbe:
+    httpGet:
+      path: /health/readiness
+      port: http
+    initialDelaySeconds: 300
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 10
+
   image:
     repository: quay.io/hmpps/hmpps-manage-adjudications-api
     tag: app_version # override at deployment time

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/job/FixLocationsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/job/FixLocationsJob.kt
@@ -24,14 +24,14 @@ class FixLocationsJob(
     }
     log.info("fixIncidentDetailsLocations took ${elapsedId}ms")
 
-    val elapsedRa = measureTimeMillis {
-      fixLocationsService.fixReportedAdjudicationLocations()
-    }
-    log.info("fixReportedAdjudicationLocations took ${elapsedRa}ms")
+//    val elapsedRa = measureTimeMillis {
+//      fixLocationsService.fixReportedAdjudicationLocations()
+//    }
+//    log.info("fixReportedAdjudicationLocations took ${elapsedRa}ms")
 
-    val elapsedH = measureTimeMillis {
-      fixLocationsService.fixHearingLocations()
-    }
-    log.info("fixHearingLocations took ${elapsedH}ms")
+//    val elapsedH = measureTimeMillis {
+//      fixLocationsService.fixHearingLocations()
+//    }
+//    log.info("fixHearingLocations took ${elapsedH}ms")
   }
 }

--- a/src/main/resources/db/migration/V127__location_id_indexes.sql
+++ b/src/main/resources/db/migration/V127__location_id_indexes.sql
@@ -1,4 +1,2 @@
 --temp indexes for updating location ids
 create index incident_details_location_idx on incident_details (location_id);
-create index reported_adjudications_location_idx on reported_adjudications (location_id);
-create index hearing_location_idx on hearing (location_id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/FixLocationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/FixLocationIntTest.kt
@@ -4,6 +4,7 @@ import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.reset
@@ -73,7 +74,7 @@ class FixLocationIntTest : SqsIntegrationTestBase() {
     verify(locationService, times(0)).getNomisLocationDetail(eq("45678"))
   }
 
-  @Test
+  @Test @Disabled
   fun `run location job for updating reported adjudications`() {
     val testAdjudication1 = IntegrationTestData.getDefaultAdjudication().copy(locationId = 12345, locationUuid = null)
     val intTestData1 = integrationTestData()
@@ -150,7 +151,7 @@ class FixLocationIntTest : SqsIntegrationTestBase() {
     verify(locationService, times(0)).getNomisLocationDetail(eq("34567"))
   }
 
-  @Test
+  @Test @Disabled
   fun `run location job for updating hearings`() {
     val testData = IntegrationTestData.getDefaultAdjudication()
     val scenario = initDataForUnScheduled(testData = testData)


### PR DESCRIPTION
Increase the timeout for the readiness probe as the index can take a long time to run