### PR TITLE
MAP-2120: run a job to update the location uuid

### DIFF
--- a/helm_deploy/hmpps-manage-adjudications-api/values.yaml
+++ b/helm_deploy/hmpps-manage-adjudications-api/values.yaml
@@ -6,24 +6,6 @@ generic-service:
 
   replicaCount: 4
 
-  livenessProbe:
-    httpGet:
-      path: /health/liveness
-      port: http
-    initialDelaySeconds: 300
-    periodSeconds: 10
-    timeoutSeconds: 10
-    failureThreshold: 10
-
-  readinessProbe:
-    httpGet:
-      path: /health/readiness
-      port: http
-    initialDelaySeconds: 300
-    periodSeconds: 10
-    timeoutSeconds: 10
-    failureThreshold: 10
-
   image:
     repository: quay.io/hmpps/hmpps-manage-adjudications-api
     tag: app_version # override at deployment time

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/job/FixLocationsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/job/FixLocationsJob.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.job
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.FixLocationsService
 import kotlin.system.measureTimeMillis
@@ -16,7 +15,6 @@ class FixLocationsJob(
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  @Async("asyncExecutor")
   fun execute() {
     log.info("executing fix location job")
     val elapsedId = measureTimeMillis {
@@ -24,14 +22,14 @@ class FixLocationsJob(
     }
     log.info("fixIncidentDetailsLocations took ${elapsedId}ms")
 
-//    val elapsedRa = measureTimeMillis {
-//      fixLocationsService.fixReportedAdjudicationLocations()
-//    }
-//    log.info("fixReportedAdjudicationLocations took ${elapsedRa}ms")
+    val elapsedRa = measureTimeMillis {
+      fixLocationsService.fixReportedAdjudicationLocations()
+    }
+    log.info("fixReportedAdjudicationLocations took ${elapsedRa}ms")
 
-//    val elapsedH = measureTimeMillis {
-//      fixLocationsService.fixHearingLocations()
-//    }
-//    log.info("fixHearingLocations took ${elapsedH}ms")
+    val elapsedH = measureTimeMillis {
+      fixLocationsService.fixHearingLocations()
+    }
+    log.info("fixHearingLocations took ${elapsedH}ms")
   }
 }

--- a/src/main/resources/db/migration/V127__location_id_indexes.sql
+++ b/src/main/resources/db/migration/V127__location_id_indexes.sql
@@ -1,2 +1,0 @@
---temp indexes for updating location ids
-create index incident_details_location_idx on incident_details (location_id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/FixLocationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/FixLocationIntTest.kt
@@ -4,7 +4,6 @@ import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.reset
@@ -74,7 +73,7 @@ class FixLocationIntTest : SqsIntegrationTestBase() {
     verify(locationService, times(0)).getNomisLocationDetail(eq("45678"))
   }
 
-  @Test @Disabled
+  @Test
   fun `run location job for updating reported adjudications`() {
     val testAdjudication1 = IntegrationTestData.getDefaultAdjudication().copy(locationId = 12345, locationUuid = null)
     val intTestData1 = integrationTestData()
@@ -151,7 +150,7 @@ class FixLocationIntTest : SqsIntegrationTestBase() {
     verify(locationService, times(0)).getNomisLocationDetail(eq("34567"))
   }
 
-  @Test @Disabled
+  @Test
   fun `run location job for updating hearings`() {
     val testData = IntegrationTestData.getDefaultAdjudication()
     val scenario = initDataForUnScheduled(testData = testData)


### PR DESCRIPTION
Temporary job to update the 3 different tables incident_details, reported_adjudications, hearings. Removed the index creation via flyway which had caused timeout on deployment. 
Remove the extended delay which was specifically added to allow time for the indexes to be created.
The job is for a single run. The indexes to be created and removed after the job has run outside of flyway.