### PR TITLE
stop filtering punishments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/entities/ReportedAdjudication.kt
@@ -273,9 +273,10 @@ data class ReportedAdjudication(
     fun List<Punishment>.toPunishmentsDto(
       hasLinkedAda: Boolean,
       consecutiveReportsAvailable: List<String>? = null,
-    ): MutableList<PunishmentDto> = this.filter { punishment ->
-      !hasLinkedAda || (punishment.type in PunishmentType.additionalDays())
-    }.sortedBy { it.type }.map { it.toDto(hasLinkedAda, consecutiveReportsAvailable) }.toMutableList()
+    ): MutableList<PunishmentDto> = this
+      .sortedBy { it.type }
+      .map { it.toDto(hasLinkedAda, consecutiveReportsAvailable) }
+      .toMutableList()
 
     private fun HearingDto.hearingHasNoAssociatedOutcome() = this.outcome == null || this.outcome.code == HearingOutcomeCode.ADJOURN
 


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LSM-252

changed `toPunishmentsDto()` to stop filtering punishments when `hasLinkedAda` is `true`, and instead always return all punishments. `hasLinkedAda` is still passed into `Punishment.toDto()` so the “canRemove/canEdit” behaviour for ADA (linked) remains intact.

**Updated**: `ReportedAdjudication.Companion.toPunishmentsDto()` to always map all punishments.
**Added**: regression test non-ADA punishments are included even when has linked consecutive ADA.