### PR TITLE
adding log to be sure the endpoint is been triggered while investigating the slow query

### DIFF
--- a/src/main/resources/db/migration/V129__punishment_schedule_end_date_idx.sql
+++ b/src/main/resources/db/migration/V129__punishment_schedule_end_date_idx.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS punishment_schedule_end_date_idx ON punishment_schedule (end_date);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepositoryTest.kt
@@ -1048,12 +1048,14 @@ class ReportedAdjudicationRepositoryTest {
 
   @Test
   fun `get active punishments`() {
+    val ids = reportedAdjudicationRepository.findIdsForActivePunishmentsByBookingId(
+      ReportedAdjudicationStatus.CHARGE_PROVED.name,
+      1L,
+      LocalDate.now().minusDays(1),
+    )
+    assertThat(ids.size).isEqualTo(1)
     assertThat(
-      reportedAdjudicationRepository.findByStatusAndOffenderBookingIdAndPunishmentsSuspendedUntilIsNullAndPunishmentsScheduleEndDateIsAfter(
-        ReportedAdjudicationStatus.CHARGE_PROVED,
-        1L,
-        LocalDate.now().minusDays(1),
-      ).size,
+      reportedAdjudicationRepository.findByIdsWithPunishments(ids).size,
     ).isEqualTo(1)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/SummaryAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/SummaryAdjudicationServiceTest.kt
@@ -73,11 +73,15 @@ class SummaryAdjudicationServiceTest : ReportedAdjudicationTestBase() {
       ).thenReturn(2)
 
       whenever(
-        reportedAdjudicationRepository.findByStatusAndOffenderBookingIdAndPunishmentsSuspendedUntilIsNullAndPunishmentsScheduleEndDateIsAfter(
+        reportedAdjudicationRepository.findIdsForActivePunishmentsByBookingId(
           any(),
           any(),
           any(),
         ),
+      ).thenReturn(listOf(1L))
+
+      whenever(
+        reportedAdjudicationRepository.findByIdsWithPunishments(any()),
       ).thenReturn(listOf(basicData))
 
       val response =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsReportsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsReportsServiceTest.kt
@@ -394,11 +394,15 @@ class PunishmentsReportsServiceTest : ReportedAdjudicationTestBase() {
     @Test
     fun `get activated from with other privilege`() {
       whenever(
-        reportedAdjudicationRepository.findByStatusAndOffenderBookingIdAndPunishmentsSuspendedUntilIsNullAndPunishmentsScheduleEndDateIsAfter(
+        reportedAdjudicationRepository.findIdsForActivePunishmentsByBookingId(
           any(),
           any(),
           any(),
         ),
+      ).thenReturn(listOf(1L))
+
+      whenever(
+        reportedAdjudicationRepository.findByIdsWithPunishments(any()),
       ).thenReturn(
         listOf(
           entityBuilder.reportedAdjudication().also {
@@ -432,11 +436,15 @@ class PunishmentsReportsServiceTest : ReportedAdjudicationTestBase() {
     @Test
     fun `get with stoppage percentage`() {
       whenever(
-        reportedAdjudicationRepository.findByStatusAndOffenderBookingIdAndPunishmentsSuspendedUntilIsNullAndPunishmentsScheduleEndDateIsAfter(
+        reportedAdjudicationRepository.findIdsForActivePunishmentsByBookingId(
           any(),
           any(),
           any(),
         ),
+      ).thenReturn(listOf(1L))
+
+      whenever(
+        reportedAdjudicationRepository.findByIdsWithPunishments(any()),
       ).thenReturn(
         listOf(
           entityBuilder.reportedAdjudication().also {


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LSM-312

I replaced the previous @EntityGraph + JPQL with a two-query strategy:

1. Query 1 — fast native SQL to find IDs (findIdsForActivePunishmentsByBookingId)

Efficient 3-table JOIN using indexes
Returns only adjudication IDs (minimal data transfer)
Short-circuits with emptyList() if no matches

2. Query 2 — JPQL with LEFT JOIN FETCH (findByIdsWithPunishments)

Fetches adjudications by ID with punishments eagerly loaded
Eliminates N+1 (punishments loaded in one query, schedules come along via FetchType.EAGER)