### PR TITLE
LSM-443/Incorrect-information-displaying-on-DIS5

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/OffenceCodes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/OffenceCodes.kt
@@ -731,7 +731,7 @@ enum class OffenceCodes(
     fun Int.containsNomisCode(nomisCode: String): Boolean {
       val offenceCode = entries.first { it.uniqueOffenceCodes.contains(this) }
 
-      return offenceCode.nomisCode == nomisCode || offenceCode.getNomisCodeWithOthers().contains(nomisCode)
+        return offenceCode.nomisCode == nomisCode || offenceCode.getNomisCodeWithOthers() == nomisCode
     }
   }
 }


### PR DESCRIPTION
replaced .contains() with == to rectify form issue