### PR TITLE
IR-1715 Fix looped consecutive punishments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/ScheduleTaskController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/controllers/ScheduleTaskController.kt
@@ -3,9 +3,13 @@ package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.controllers
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.AdjudicationDomainEventType
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.EventPublishService
 import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.draft.DraftAdjudicationService
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported.ConsecutivePunishmentCorrectionService
 
 @RestController
 @Hidden
@@ -13,8 +17,17 @@ import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.draft.D
 @RequestMapping("/scheduled-tasks")
 class ScheduleTaskController(
   private val draftAdjudicationService: DraftAdjudicationService,
+  private val consecutivePunishmentCorrectionService: ConsecutivePunishmentCorrectionService,
+  private val eventPublishService: EventPublishService,
 ) {
 
   @DeleteMapping(value = ["/delete-orphaned-draft-adjudications"])
   fun deleteOrphanedDraftAdjudications(): Unit = draftAdjudicationService.deleteOrphanedDraftAdjudications()
+
+  @PostMapping(value = ["/fix-consecutive-punishment-loops"])
+  fun fixConsecutivePunishmentLoops() {
+    consecutivePunishmentCorrectionService.clearLoopedConsecutivePunishments().forEach {
+      eventPublishService.publishEvent(AdjudicationDomainEventType.PUNISHMENTS_UPDATED, it)
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/repositories/ReportedAdjudicationRepository.kt
@@ -193,6 +193,41 @@ interface ReportedAdjudicationRepository : CrudRepository<ReportedAdjudication, 
     @Param("types") types: List<String>,
   ): List<ReportedAdjudication>
 
+  @Query(
+    value = """
+      WITH looped_charges AS (
+        SELECT DISTINCT
+          CASE
+            WHEN ra1.create_datetime < ra2.create_datetime THEN p1.id
+            WHEN ra2.create_datetime < ra1.create_datetime THEN p2.id
+            ELSE least(p1.id, p2.id)
+          END AS punishment_id_to_clear
+        FROM reported_adjudications ra1
+        JOIN punishment p1 ON p1.reported_adjudication_fk_id = ra1.id AND coalesce(p1.deleted, false) = false
+        JOIN reported_adjudications ra2 ON ra2.charge_number = p1.consecutive_to_charge_number
+                                       AND ra2.prisoner_number = ra1.prisoner_number
+        JOIN punishment p2 ON p2.reported_adjudication_fk_id = ra2.id AND coalesce(p2.deleted, false) = false
+        WHERE p2.consecutive_to_charge_number = ra1.charge_number
+          AND ra1.id < ra2.id
+      )
+      SELECT punishment_id_to_clear FROM looped_charges
+    """,
+    nativeQuery = true,
+  )
+  fun findLoopedConsecutivePunishmentIdsToClear(): List<Long>
+
+  @Query(
+    value = """
+      SELECT DISTINCT ra.* FROM reported_adjudications ra
+      JOIN punishment p ON p.reported_adjudication_fk_id = ra.id
+      WHERE p.id IN :punishmentIds
+    """,
+    nativeQuery = true,
+  )
+  fun findByPunishmentIdIn(
+    @Param("punishmentIds") punishmentIds: List<Long>,
+  ): List<ReportedAdjudication>
+
   @Query(value = "SELECT nextval(:sequenceName)", nativeQuery = true)
   fun getNextChargeSequence(
     @Param("sequenceName") sequenceName: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ConsecutivePunishmentCorrectionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ConsecutivePunishmentCorrectionService.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.ReportedAdjudicationDto
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.OffenceCodeLookupService
+
+/**
+ * Corrects self-referential (looped) consecutive punishments, where two charges for the same
+ * prisoner are mutually consecutive (punishment on charge A consecutive to charge B and the
+ * punishment on charge B consecutive to charge A). Only the more recently created charge should
+ * remain consecutive to the older one, so the consecutive link is cleared from the punishment
+ * belonging to the earlier-created charge. These loops break downstream services such as
+ * Calculate Release Dates.
+ */
+@Service
+class ConsecutivePunishmentCorrectionService(
+  private val reportedAdjudicationRepository: ReportedAdjudicationRepository,
+  private val offenceCodeLookupService: OffenceCodeLookupService,
+) {
+
+  @Transactional
+  fun clearLoopedConsecutivePunishments(): List<ReportedAdjudicationDto> {
+    val idsToClear = reportedAdjudicationRepository.findLoopedConsecutivePunishmentIdsToClear()
+    if (idsToClear.isEmpty()) return emptyList()
+
+    return reportedAdjudicationRepository.findByPunishmentIdIn(idsToClear).map { report ->
+      report.getPunishments().filter { idsToClear.contains(it.id) }.forEach {
+        log.info("clearing looped consecutive punishment ${it.id} on charge ${report.chargeNumber}")
+        it.consecutiveToChargeNumber = null
+      }
+      report.toDto(offenceCodeLookupService)
+    }
+  }
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ConsecutivePunishmentCorrectionIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ConsecutivePunishmentCorrectionIntTest.kt
@@ -1,0 +1,119 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.springframework.context.annotation.Import
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.config.TestOAuth2Config
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.dtos.ReportedAdjudicationDto
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Punishment
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentSchedule
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentType
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudication
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.AdjudicationDomainEventType
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.EventPublishService
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.utils.EntityBuilder
+import java.time.LocalDateTime
+
+@Import(TestOAuth2Config::class)
+class ConsecutivePunishmentCorrectionIntTest : SqsIntegrationTestBase() {
+
+  @MockitoSpyBean
+  private lateinit var eventPublishService: EventPublishService
+
+  private val entityBuilder = EntityBuilder()
+
+  private val olderCharge = "INT-1"
+  private val newerCharge = "INT-2"
+  private val prisoner = "INT123"
+
+  @BeforeEach
+  fun setUp() {
+    // seed via the repository directly, so populate the security context that JPA auditing
+    // (@CreatedBy / @LastModifiedBy) reads to fill the non-null create_user_id / modify_user_id
+    SecurityContextHolder.getContext().authentication =
+      UsernamePasswordAuthenticationToken("ITAG_USER", null, emptyList())
+
+    // older charge, created first, consecutive to the newer charge (the link to clear)
+    saveReport(chargeNumber = olderCharge, consecutiveTo = newerCharge, createdAt = LocalDateTime.of(2023, 1, 1, 9, 0))
+    // newer charge, created second, consecutive to the older charge (the link to keep)
+    saveReport(chargeNumber = newerCharge, consecutiveTo = olderCharge, createdAt = LocalDateTime.of(2023, 1, 2, 9, 0))
+  }
+
+  @AfterEach
+  fun tearDown() {
+    SecurityContextHolder.clearContext()
+  }
+
+  @Test
+  fun `clears the older charge's consecutive link and fires a re-sync event for it`() {
+    webTestClient.post()
+      .uri("/scheduled-tasks/fix-consecutive-punishment-loops")
+      .exchange()
+      .expectStatus().isOk
+
+    assertConsecutiveLink(olderCharge, expected = null)
+    assertConsecutiveLink(newerCharge, expected = olderCharge)
+
+    verify(eventPublishService, times(1)).publishEvent(
+      eq(AdjudicationDomainEventType.PUNISHMENTS_UPDATED),
+      argThat<ReportedAdjudicationDto> { chargeNumber == olderCharge },
+    )
+  }
+
+  @Test
+  fun `is idempotent - a second run clears nothing and fires no events`() {
+    webTestClient.post().uri("/scheduled-tasks/fix-consecutive-punishment-loops").exchange().expectStatus().isOk
+    reset(eventPublishService)
+
+    webTestClient.post().uri("/scheduled-tasks/fix-consecutive-punishment-loops").exchange().expectStatus().isOk
+
+    verify(eventPublishService, never()).publishEvent(any(), any())
+    assertConsecutiveLink(olderCharge, expected = null)
+    assertConsecutiveLink(newerCharge, expected = olderCharge)
+  }
+
+  private fun saveReport(chargeNumber: String, consecutiveTo: String, createdAt: LocalDateTime) {
+    setAuditTime(createdAt)
+    val report: ReportedAdjudication = entityBuilder.reportedAdjudication(
+      chargeNumber = chargeNumber,
+      prisonerNumber = prisoner,
+      hearingId = null,
+    ).also {
+      it.addPunishment(
+        Punishment(
+          type = PunishmentType.ADDITIONAL_DAYS,
+          consecutiveToChargeNumber = consecutiveTo,
+          schedule = mutableListOf(PunishmentSchedule(duration = 5)),
+        ),
+      )
+    }
+    reportedAdjudicationRepository.save(report)
+  }
+
+  private fun assertConsecutiveLink(chargeNumber: String, expected: String?) {
+    val body = webTestClient.get()
+      .uri("/reported-adjudications/$chargeNumber/v2")
+      .headers(setHeaders())
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+
+    val path = "$.reportedAdjudication.punishments[0].consecutiveChargeNumber"
+    if (expected == null) {
+      body.jsonPath(path).doesNotExist()
+    } else {
+      body.jsonPath(path).isEqualTo(expected)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ConsecutivePunishmentCorrectionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ConsecutivePunishmentCorrectionServiceTest.kt
@@ -1,0 +1,68 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.reported
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Punishment
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentSchedule
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentType
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.repositories.ReportedAdjudicationRepository
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.OffenceCodeLookupService
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.utils.EntityBuilder
+
+class ConsecutivePunishmentCorrectionServiceTest {
+
+  private val reportedAdjudicationRepository: ReportedAdjudicationRepository = mock()
+  private val offenceCodeLookupService: OffenceCodeLookupService = OffenceCodeLookupService()
+  private val entityBuilder = EntityBuilder()
+
+  private val service = ConsecutivePunishmentCorrectionService(
+    reportedAdjudicationRepository,
+    offenceCodeLookupService,
+  )
+
+  @Test
+  fun `does nothing when there are no looped consecutive punishments`() {
+    whenever(reportedAdjudicationRepository.findLoopedConsecutivePunishmentIdsToClear()).thenReturn(emptyList())
+
+    val result = service.clearLoopedConsecutivePunishments()
+
+    assertThat(result).isEmpty()
+    verify(reportedAdjudicationRepository, never()).findByPunishmentIdIn(any())
+  }
+
+  @Test
+  fun `only clears the punishment whose id is flagged, leaving others untouched`() {
+    val report = entityBuilder.reportedAdjudication(chargeNumber = "A-1").also {
+      it.addPunishment(
+        Punishment(
+          id = 1,
+          type = PunishmentType.ADDITIONAL_DAYS,
+          consecutiveToChargeNumber = "A-2",
+          schedule = mutableListOf(PunishmentSchedule(duration = 1)),
+        ),
+      )
+      it.addPunishment(
+        Punishment(
+          id = 2,
+          type = PunishmentType.ADDITIONAL_DAYS,
+          consecutiveToChargeNumber = "A-3",
+          schedule = mutableListOf(PunishmentSchedule(duration = 1)),
+        ),
+      )
+    }
+
+    whenever(reportedAdjudicationRepository.findLoopedConsecutivePunishmentIdsToClear()).thenReturn(listOf(1))
+    whenever(reportedAdjudicationRepository.findByPunishmentIdIn(listOf(1))).thenReturn(listOf(report))
+
+    val result = service.clearLoopedConsecutivePunishments()
+
+    assertThat(result).hasSize(1)
+    assertThat(report.getPunishments().first { it.id == 1L }.consecutiveToChargeNumber).isNull()
+    assertThat(report.getPunishments().first { it.id == 2L }.consecutiveToChargeNumber).isEqualTo("A-3")
+  }
+}


### PR DESCRIPTION
## Problem

Two charges for the same prisoner can end up **mutually consecutive** — the punishment on charge A is consecutive to charge B *and* the punishment on charge B is consecutive to charge A (mostly from migrated NOMIS data, but also reproducible through the current UI). Only the more recently created charge should remain consecutive to the older one. These loops break Calculate Release Dates and other downstream services. ~459 instances were identified in PreProd.

A raw SQL `UPDATE` isn't viable because NOMIS sync would never see the change — it has to be done in the service so a domain event is fired for re-sync.

## Change

Adds a permitAll maintenance endpoint **`POST /scheduled-tasks/fix-consecutive-punishment-loops`** (same pattern as the existing `delete-orphaned-draft-adjudications`), so it can be run on demand now and wired to a k8s CronJob later. It is idempotent.

It:
- finds mutually-consecutive punishment pairs (the agreed `looped_charges` CTE);
- clears `consecutiveToChargeNumber` on the punishment belonging to the **earlier-created** charge (tie-broken by `least(p1.id, p2.id)`), keeping the newer charge's link, inside a `@Transactional` service method;
- publishes a `PUNISHMENTS_UPDATED` domain event per affected charge **after the transaction commits** (at the controller boundary, mirroring `eventPublishWrapper`) so NOMIS re-syncs.

Files: `ReportedAdjudicationRepository` (two native queries), new `ConsecutivePunishmentCorrectionService`, `ScheduleTaskController`, plus a unit test and an integration test.

> Note: the front-end / API validation to stop new mutual loops being created is a deliberate **second step**, out of scope here.

## Verification

- `ConsecutivePunishmentCorrectionServiceTest` (unit) passes.
- `ConsecutivePunishmentCorrectionIntTest` (integration, Testcontainers Postgres + LocalStack) passes: seeds a mutual loop, calls the endpoint, asserts the older charge's link is cleared, the newer charge's link is kept, a single `PUNISHMENTS_UPDATED` event is fired for the older charge, and a second run is a no-op.
