### PR TITLE
IR-1715 Prevent consecutive punishment loops at create/update

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsService.kt
@@ -40,6 +40,8 @@ class PunishmentsService(
     chargeNumber: String,
     punishments: List<PunishmentRequest>,
   ): ReportedAdjudicationDto {
+    validateNoConsecutiveLoop(chargeNumber, punishments)
+
     val reportedAdjudication = findByChargeNumber(chargeNumber).also {
       if (it.getPunishments()
           .isNotEmpty()
@@ -82,6 +84,8 @@ class PunishmentsService(
     chargeNumber: String,
     punishments: List<PunishmentRequest>,
   ): ReportedAdjudicationDto {
+    validateNoConsecutiveLoop(chargeNumber, punishments)
+
     val reportedAdjudication = findByChargeNumber(chargeNumber).also {
       it.validateCanAddPunishments()
     }
@@ -258,6 +262,23 @@ class PunishmentsService(
     }
 
     return suspendedPunishmentEvents
+  }
+
+  private fun validateNoConsecutiveLoop(chargeNumber: String, punishments: List<PunishmentRequest>) {
+    val requestedConsecutiveTargets = punishments
+      .filter { PunishmentType.additionalDays().contains(it.type) }
+      .mapNotNull { it.consecutiveChargeNumber }
+      .toSet()
+    if (requestedConsecutiveTargets.isEmpty()) return
+
+    if (requestedConsecutiveTargets.contains(chargeNumber)) {
+      throw ValidationException("a punishment cannot be consecutive to its own charge $chargeNumber")
+    }
+
+    val chargesConsecutiveToThis = chargesConsecutiveTo(chargeNumber, PunishmentType.additionalDays()).toSet()
+    requestedConsecutiveTargets.firstOrNull { chargesConsecutiveToThis.contains(it) }?.let {
+      throw ValidationException("charge $chargeNumber cannot be consecutive to $it because $it is already consecutive to this charge")
+    }
   }
 
   private fun PunishmentType.consecutiveReportValidation(chargeNumber: String) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/ReportedAdjudicationBaseService.kt
@@ -68,6 +68,11 @@ open class ReportedAdjudicationBaseService(
     ).isNotEmpty()
   }
 
+  protected fun chargesConsecutiveTo(consecutiveChargeNumber: String, types: List<PunishmentType>): List<String> = reportedAdjudicationRepository.findByPunishmentsConsecutiveToChargeNumberAndPunishmentsTypeInV2(
+    consecutiveChargeNumber,
+    types.map { it.name },
+  ).map { it.chargeNumber }
+
   protected fun findMultipleOffenceCharges(prisonerNumber: String, chargeNumber: String): List<String> = reportedAdjudicationRepository.findByPrisonerNumberAndChargeNumberStartsWith(
     prisonerNumber = prisonerNumber,
     chargeNumber = "${chargeNumber.substringBefore("-")}-",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/PunishmentsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/PunishmentsIntTest.kt
@@ -48,6 +48,35 @@ class PunishmentsIntTest : SqsIntegrationTestBase() {
       )
   }
 
+  @Test
+  fun `rejects creating a consecutive loop with a 400`() {
+    val chargeX = initDataForUnScheduled(testData = IntegrationTestData.getDefaultAdjudication())
+      .createHearing(oicHearingType = OicHearingType.INAD_ADULT).createChargeProved().getGeneratedChargeNumber()
+    val chargeY = initDataForUnScheduled(testData = IntegrationTestData.getDefaultAdjudication())
+      .createHearing(oicHearingType = OicHearingType.INAD_ADULT).createChargeProved().getGeneratedChargeNumber()
+
+    // charge Y is already consecutive to charge X
+    createPunishments(
+      chargeNumber = chargeY,
+      type = PunishmentType.ADDITIONAL_DAYS,
+      consecutiveChargeNumber = chargeX,
+      isSuspended = false,
+    ).expectStatus().isCreated
+
+    // making charge X consecutive to charge Y would close the loop - reject it
+    createPunishments(
+      chargeNumber = chargeX,
+      type = PunishmentType.ADDITIONAL_DAYS,
+      consecutiveChargeNumber = chargeY,
+      isSuspended = false,
+    )
+      .expectStatus().isBadRequest
+      .expectBody()
+      .jsonPath("$.userMessage").isEqualTo(
+        "Validation failure: charge $chargeX cannot be consecutive to $chargeY because $chargeY is already consecutive to this charge",
+      )
+  }
+
   @CsvSource("true", "false")
   @ParameterizedTest
   fun `create a payback punishment`(hasDetails: Boolean) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/services/reported/PunishmentsServiceTest.kt
@@ -125,6 +125,39 @@ class PunishmentsServiceTest : ReportedAdjudicationTestBase() {
 
     @CsvSource("ADDITIONAL_DAYS", "PROSPECTIVE_DAYS")
     @ParameterizedTest
+    fun `throws validation exception when creating a consecutive loop`(punishmentType: PunishmentType) {
+      whenever(
+        reportedAdjudicationRepository.findByPunishmentsConsecutiveToChargeNumberAndPunishmentsTypeInV2(
+          "1",
+          listOf("ADDITIONAL_DAYS", "PROSPECTIVE_DAYS"),
+        ),
+      ).thenReturn(
+        listOf(entityBuilder.reportedAdjudication(chargeNumber = "2")),
+      )
+
+      assertThatThrownBy {
+        punishmentsService.create(
+          chargeNumber = "1",
+          listOf(PunishmentRequest(type = punishmentType, consecutiveChargeNumber = "2", duration = 1)),
+        )
+      }.isInstanceOf(ValidationException::class.java)
+        .hasMessageContaining("charge 1 cannot be consecutive to 2 because 2 is already consecutive to this charge")
+    }
+
+    @CsvSource("ADDITIONAL_DAYS", "PROSPECTIVE_DAYS")
+    @ParameterizedTest
+    fun `throws validation exception when consecutive to its own charge`(punishmentType: PunishmentType) {
+      assertThatThrownBy {
+        punishmentsService.create(
+          chargeNumber = "1",
+          listOf(PunishmentRequest(type = punishmentType, consecutiveChargeNumber = "1", duration = 1)),
+        )
+      }.isInstanceOf(ValidationException::class.java)
+        .hasMessageContaining("a punishment cannot be consecutive to its own charge 1")
+    }
+
+    @CsvSource("ADDITIONAL_DAYS", "PROSPECTIVE_DAYS")
+    @ParameterizedTest
     fun `throws exception if not inad hearing `(punishmentType: PunishmentType) {
       whenever(reportedAdjudicationRepository.findByChargeNumber(any())).thenReturn(
         reportedAdjudication.also {
@@ -1020,6 +1053,33 @@ class PunishmentsServiceTest : ReportedAdjudicationTestBase() {
         )
       }.isInstanceOf(ValidationException::class.java)
         .hasMessageContaining("Unable to modify: $type is linked to another report")
+    }
+
+    @CsvSource("ADDITIONAL_DAYS", "PROSPECTIVE_DAYS")
+    @ParameterizedTest
+    fun `throws validation exception when updating to create a consecutive loop`(type: PunishmentType) {
+      whenever(reportedAdjudicationRepository.findByChargeNumber(any())).thenReturn(
+        entityBuilder.reportedAdjudication().also {
+          it.status = ReportedAdjudicationStatus.CHARGE_PROVED
+        },
+      )
+
+      whenever(
+        reportedAdjudicationRepository.findByPunishmentsConsecutiveToChargeNumberAndPunishmentsTypeInV2(
+          "1",
+          listOf("ADDITIONAL_DAYS", "PROSPECTIVE_DAYS"),
+        ),
+      ).thenReturn(
+        listOf(entityBuilder.reportedAdjudication(chargeNumber = "2")),
+      )
+
+      assertThatThrownBy {
+        punishmentsService.update(
+          chargeNumber = "1",
+          punishments = listOf(PunishmentRequest(type = type, consecutiveChargeNumber = "2", duration = 1)),
+        )
+      }.isInstanceOf(ValidationException::class.java)
+        .hasMessageContaining("charge 1 cannot be consecutive to 2 because 2 is already consecutive to this charge")
     }
 
     @Test


### PR DESCRIPTION
## What

Reject, with HTTP 400, any punishment request that would make two charges mutually consecutive (charge X consecutive to charge Y while charge Y is already consecutive to charge X), or that points a charge consecutive to itself.

## Why

Mutually-consecutive ("looped") punishments break downstream services such as Calculate Release Dates. Until now nothing prevented the loop being created; it could only be repaired after the fact via the `POST /scheduled-tasks/fix-consecutive-punishment-loops` housekeeping endpoint. This change stops the loop being created in the first place.

## How

- Added `validateNoConsecutiveLoop(...)` to `PunishmentsService`, invoked at the top of both `create` and `update` before any punishment is persisted.
- Added a `chargesConsecutiveTo(...)` helper to `ReportedAdjudicationBaseService`, reusing the existing `findByPunishmentsConsecutiveToChargeNumberAndPunishmentsTypeInV2` query (no new query, and no 404 risk from loading the target report).
- `ValidationException` already maps to a 400 via `ApiExceptionHandler`.

## Tests

- Unit tests in `PunishmentsServiceTest` for the loop and self-reference cases on both create and update.
- Integration test in `PunishmentsIntTest` asserting the request is rejected with a 400.