### PR TITLE
IR-1797 Publish an adjudications data dictionary

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -60,6 +60,13 @@ jobs:
       postgres-username: adjudications
       postgres-password: adjudications
       localstack-tag: community-archive
+  schema-spy:
+    name: Publish the data dictionary
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - gradle_verify
+    uses: ./.github/workflows/schema-spy.yml
+    secrets: inherit
   build:
     name: Build docker image from hmpps-github-actions
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION

--- a/.github/workflows/schema-spy.yml
+++ b/.github/workflows/schema-spy.yml
@@ -1,0 +1,106 @@
+name: SchemaSpy report
+
+# Publishes the adjudications data dictionary:
+#   https://ministryofjustice.github.io/hmpps-manage-adjudications-api/schema-spy-report/
+#
+# Three artefacts are produced from one Flyway-built database:
+#   - the SchemaSpy report (browsable ER diagrams and table docs)
+#   - data-dictionary.csv (flat table/column export for the MOJ Data Catalogue / Glue)
+#   - reference-data.csv (enum and offence code lookups, which have no tables in the database)
+#
+# Column descriptions come from db/migration/V130__schema_comments.sql.
+
+on:
+  workflow_call:
+    inputs:
+      java_version:
+        description: Java version
+        type: string
+        default: '25'
+      java_options:
+        description: Java options
+        type: string
+        default: '-Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process'
+      docker_compose_file:
+        description: Path to Docker Compose file to start required containers
+        type: string
+        default: 'docker-compose-schema-spy.yml'
+      database_name:
+        description: Database name
+        type: string
+        default: 'adjudications'
+      database_user:
+        description: Database user name
+        type: string
+        default: 'adjudications'
+      database_password:
+        description: Database user password
+        type: string
+        default: 'adjudications'
+      database_schema:
+        description: Database schema name
+        type: string
+        default: 'public'
+      publish:
+        description: Publish the report to GitHub Pages
+        type: boolean
+        default: true
+
+jobs:
+  schema-spy:
+    name: Schema Spy report generation
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: test
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Java
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        with:
+          distribution: temurin
+          java-version: ${{ inputs.java_version }}
+          cache: gradle
+          cache-dependency-path: |
+            *.gradle*
+            **/gradle-wrapper.properties
+
+      - name: Initialise database and export reference data
+        shell: bash
+        run: |
+          docker compose -f ${{ inputs.docker_compose_file }} up -d
+          export JAVA_OPTS="${{ inputs.java_options }}"
+          ./gradlew -Pinit-db=true -PreferenceDataOutput="${PWD}/reference-data.csv" test \
+            --tests uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration.InitialiseDatabase \
+            --tests uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration.ExportReferenceData
+
+      - name: Generate database schema report
+        uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/database_schema_report@c89a206b6b32888d13f6aec01af0f7694df6b42f # v1.0.19
+        with:
+          database_name: ${{ inputs.database_name }}
+          schema: ${{ inputs.database_schema }}
+          user: ${{ inputs.database_user }}
+          password: ${{ inputs.database_password }}
+
+      - name: Generate CSV data dictionary
+        shell: bash
+        env:
+          DB_NAME: ${{ inputs.database_name }}
+          DB_USER: ${{ inputs.database_user }}
+          DB_PASSWORD: ${{ inputs.database_password }}
+          DB_SCHEMA: ${{ inputs.database_schema }}
+        run: |
+          scripts/generate-data-dictionary.sh /tmp/schemaspy/data-dictionary.csv
+          cp reference-data.csv /tmp/schemaspy/reference-data.csv
+
+      - name: Publish to GitHub Pages
+        if: ${{ inputs.publish }}
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
+        with:
+          branch: gh-pages
+          folder: /tmp/schemaspy
+          target-folder: schema-spy-report

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ ecr.repo
 
 #Helm
 **/Chart.lock
+
+# Generated data dictionary artefacts - published to GitHub Pages, not committed
+/data-dictionary.csv
+/reference-data.csv

--- a/README.md
+++ b/README.md
@@ -100,6 +100,33 @@ The integration tests use containers and no longer require docker compose files.
 ### Running locally
 `./gradlew bootRun --args='--spring.profiles.active=dev-local'`
 
+## Data dictionary
+
+A browsable schema report is published from `main` to
+[ministryofjustice.github.io/hmpps-manage-adjudications-api/schema-spy-report](https://ministryofjustice.github.io/hmpps-manage-adjudications-api/schema-spy-report/),
+along with two CSV exports for the MOJ Data Catalogue:
+
+| File | Contents |
+|------|----------|
+| `data-dictionary.csv` | Every table and column, with its description, type, nullability, PK and FK |
+| `reference-data.csv`  | The enum and offence code lookups. These have no reference tables in the database - `reported_offence.offence_code` and every `@Enumerated` column resolve in Kotlin only |
+
+Table and column descriptions live in `src/main/resources/db/migration/V130__schema_comments.sql` as
+`COMMENT ON` statements, so the database is the single source of truth and SchemaSpy, the CSV export
+and any Glue crawl all agree. **Add a `COMMENT ON` for any new table or column** - a later migration
+can add to or replace comments at any time.
+
+To regenerate locally:
+
+```bash
+docker compose -f docker-compose-schema-spy.yml up -d
+./gradlew -Pinit-db=true test --tests '*InitialiseDatabase' --tests '*ExportReferenceData'
+docker run --rm --network host -v /tmp/schemaspy:/output schemaspy/schemaspy:6.2.4 \
+  -t pgsql -host localhost -port 5432 -db adjudications -s public \
+  -u adjudications -p adjudications -vizjs
+scripts/generate-data-dictionary.sh
+```
+
 ## Architecture
 High Level architecture show below ![Architecture](doc/architecture/decisions/arch-overview-adjudications.svg)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,4 +95,15 @@ tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_25
   }
+
+  // Schema documentation helpers - see .github/workflows/schema-spy.yml. These build the database
+  // and export the reference data for the data dictionary, and are not part of the normal suite.
+  test {
+    if (project.hasProperty("init-db")) {
+      include("**/InitialiseDatabase.class", "**/ExportReferenceData.class")
+      systemProperty("referenceDataOutput", project.findProperty("referenceDataOutput") ?: "reference-data.csv")
+    } else {
+      exclude("**/InitialiseDatabase.class", "**/ExportReferenceData.class")
+    }
+  }
 }

--- a/docker-compose-schema-spy.yml
+++ b/docker-compose-schema-spy.yml
@@ -1,0 +1,16 @@
+services:
+  hmpps-manage-adjudications-api-db:
+    image: postgres:18
+    networks:
+      - hmpps
+    container_name: hmpps-manage-adjudications-api-db
+    restart: always
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_DB=adjudications
+      - POSTGRES_USER=adjudications
+      - POSTGRES_PASSWORD=adjudications
+
+networks:
+  hmpps:

--- a/scripts/generate-data-dictionary.sh
+++ b/scripts/generate-data-dictionary.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Exports the adjudications schema as a flat CSV data dictionary.
+#
+# The descriptions come from the COMMENT ON statements in db/migration/V130__schema_comments.sql,
+# so this is the same source of truth as the SchemaSpy report. The output is intended for the MOJ
+# Data Catalogue / AWS Glue.
+#
+# Usage:
+#   scripts/generate-data-dictionary.sh [output-file]
+#
+# Expects a database built by Flyway. Connection details are taken from the environment, defaulting
+# to the container in docker-compose-schema-spy.yml:
+#   DB_HOST (localhost) DB_PORT (5432) DB_NAME (adjudications) DB_USER (adjudications)
+#   DB_PASSWORD (adjudications) DB_SCHEMA (public)
+
+set -euo pipefail
+
+OUTPUT="${1:-data-dictionary.csv}"
+
+DB_HOST="${DB_HOST:-localhost}"
+DB_PORT="${DB_PORT:-5432}"
+DB_NAME="${DB_NAME:-adjudications}"
+DB_USER="${DB_USER:-adjudications}"
+DB_PASSWORD="${DB_PASSWORD:-adjudications}"
+DB_SCHEMA="${DB_SCHEMA:-public}"
+
+export PGPASSWORD="$DB_PASSWORD"
+
+read -r -d '' QUERY <<SQL || true
+SELECT
+  c.table_name,
+  obj_description(pc.oid)                                AS table_description,
+  c.column_name,
+  c.ordinal_position,
+  c.data_type,
+  c.character_maximum_length,
+  c.is_nullable,
+  c.column_default,
+  col_description(pc.oid, c.ordinal_position)            AS column_description,
+  CASE WHEN pk.column_name IS NOT NULL THEN 'Y' ELSE 'N' END AS is_primary_key,
+  fk.references_table                                    AS foreign_key_references
+FROM information_schema.columns c
+JOIN pg_class pc
+  ON pc.relname = c.table_name
+ AND pc.relnamespace = '${DB_SCHEMA}'::regnamespace
+ AND pc.relkind = 'r'
+LEFT JOIN (
+  SELECT kcu.table_name, kcu.column_name
+  FROM information_schema.table_constraints tc
+  JOIN information_schema.key_column_usage kcu
+    ON kcu.constraint_name = tc.constraint_name
+   AND kcu.table_schema = tc.table_schema
+  WHERE tc.constraint_type = 'PRIMARY KEY'
+    AND tc.table_schema = '${DB_SCHEMA}'
+) pk ON pk.table_name = c.table_name AND pk.column_name = c.column_name
+LEFT JOIN (
+  SELECT kcu.table_name, kcu.column_name, ccu.table_name AS references_table
+  FROM information_schema.table_constraints tc
+  JOIN information_schema.key_column_usage kcu
+    ON kcu.constraint_name = tc.constraint_name
+   AND kcu.table_schema = tc.table_schema
+  JOIN information_schema.constraint_column_usage ccu
+    ON ccu.constraint_name = tc.constraint_name
+   AND ccu.table_schema = tc.table_schema
+  WHERE tc.constraint_type = 'FOREIGN KEY'
+    AND tc.table_schema = '${DB_SCHEMA}'
+) fk ON fk.table_name = c.table_name AND fk.column_name = c.column_name
+WHERE c.table_schema = '${DB_SCHEMA}'
+  AND c.table_name <> 'flyway_schema_history'
+ORDER BY c.table_name, c.ordinal_position
+SQL
+
+COPY_COMMAND="COPY ($QUERY) TO STDOUT WITH (FORMAT csv, HEADER true)"
+
+if command -v psql > /dev/null 2>&1; then
+  psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+    -v ON_ERROR_STOP=1 -c "$COPY_COMMAND" > "$OUTPUT"
+else
+  # No local client - use the postgres image. host.docker.internal resolves on Docker Desktop,
+  # and --add-host makes it resolve on Linux too.
+  docker run --rm --add-host=host.docker.internal:host-gateway \
+    -e PGPASSWORD="$DB_PASSWORD" postgres:18 \
+    psql -h "$([ "$DB_HOST" = "localhost" ] && echo host.docker.internal || echo "$DB_HOST")" \
+    -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+    -v ON_ERROR_STOP=1 -c "$COPY_COMMAND" > "$OUTPUT"
+fi
+
+echo "Wrote $(($(wc -l < "$OUTPUT") - 1)) columns to $OUTPUT"

--- a/src/main/resources/db/migration/V130__schema_comments.sql
+++ b/src/main/resources/db/migration/V130__schema_comments.sql
@@ -1,0 +1,249 @@
+-- Data dictionary for the adjudications schema.
+--
+-- These comments are read by SchemaSpy (published to GitHub Pages) and by anything else that
+-- reads pg_description, including the CSV export consumed by the MOJ Data Catalogue / Glue.
+-- Keep them updated when columns are added or their meaning changes.
+--
+-- Audit columns common to every table (mapped from BaseEntity.kt) are not commented individually:
+--   create_user_id / create_datetime  - the DPS username and timestamp of the row's creation
+--   modify_user_id / modify_datetime  - the DPS username and timestamp of the last update
+-- Note that for records migrated from NOMIS these reflect the migration run, not the original
+-- prison event. Tables that hold the real NOMIS timestamp expose it as actual_created_date.
+
+------------------------------------------------------------------------------------------------
+-- Draft (pre-submission) side
+------------------------------------------------------------------------------------------------
+
+COMMENT ON TABLE draft_adjudications IS 'A report being written by a reporting officer, before it is submitted for review. Rows are deleted once the draft is submitted and copied into reported_adjudications, so this table holds work in progress only and is not a historic record.';
+COMMENT ON COLUMN draft_adjudications.prisoner_number IS 'NOMIS offender number (noms id) of the prisoner the charge is against.';
+COMMENT ON COLUMN draft_adjudications.offender_booking_id IS 'NOMIS OFFENDER_BOOK_ID for the prisoner''s booking at the time of the incident.';
+COMMENT ON COLUMN draft_adjudications.gender IS 'Prisoner gender, used to select the correct wording of offence paragraphs. One of MALE, FEMALE.';
+COMMENT ON COLUMN draft_adjudications.charge_number IS 'Charge number, populated only once the draft has been submitted and a reported adjudication exists. Format is <agency><6 digit sequence>, optionally suffixed -<n> for additional charges on the same incident.';
+COMMENT ON COLUMN draft_adjudications.report_by_user_id IS 'DPS username of the officer who submitted the report. Null while the draft is unsubmitted.';
+COMMENT ON COLUMN draft_adjudications.is_youth_offender IS 'True when the YOI rule set applies rather than the adult rule set. Determines which offence paragraphs and hearing types are valid.';
+COMMENT ON COLUMN draft_adjudications.originating_agency_id IS 'Agency (prison) code where the incident was reported.';
+COMMENT ON COLUMN draft_adjudications.override_agency_id IS 'Agency code the prisoner has since transferred to. Set when the report needs to be actioned by the receiving prison.';
+COMMENT ON COLUMN draft_adjudications.incident_details_id IS 'Foreign key to incident_details.';
+COMMENT ON COLUMN draft_adjudications.incident_role_id IS 'Foreign key to incident_role.';
+COMMENT ON COLUMN draft_adjudications.incident_statement_id IS 'Foreign key to incident_statement.';
+COMMENT ON COLUMN draft_adjudications.damages_saved IS 'True once the reporter has completed the damages page, including confirming there were none. Distinguishes "no damages" from "not yet asked".';
+COMMENT ON COLUMN draft_adjudications.evidence_saved IS 'True once the reporter has completed the evidence page, including confirming there was none.';
+COMMENT ON COLUMN draft_adjudications.witnesses_saved IS 'True once the reporter has completed the witnesses page, including confirming there were none.';
+COMMENT ON COLUMN draft_adjudications.created_on_behalf_of_officer IS 'Name of the officer the report was created on behalf of, when someone else entered it for them.';
+COMMENT ON COLUMN draft_adjudications.created_on_behalf_of_reason IS 'Reason the report was created on behalf of another officer.';
+
+COMMENT ON TABLE incident_details IS 'When and where the incident happened, for a draft adjudication. One row per draft.';
+COMMENT ON COLUMN incident_details.date_time_of_incident IS 'When the incident occurred.';
+COMMENT ON COLUMN incident_details.date_time_of_discovery IS 'When the incident was discovered. Equal to the incident date unless it was found later; the 48 hour notice clock runs from here.';
+COMMENT ON COLUMN incident_details.handover_deadline IS 'Deadline for issuing the notice of report to the prisoner, calculated as 48 hours after discovery.';
+COMMENT ON COLUMN incident_details.location_id IS 'Legacy NOMIS internal location id (AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID). Superseded by location_uuid.';
+COMMENT ON COLUMN incident_details.location_uuid IS 'Location identifier in the locations-inside-prison service. This is the current location reference.';
+
+COMMENT ON TABLE incident_role IS 'The prisoner''s role in the incident for a draft adjudication - whether they committed the offence themselves or attempted, incited or assisted another. One row per draft.';
+COMMENT ON COLUMN incident_role.role_code IS 'Paragraph 25 role code. Null means the prisoner committed the offence alone. 25a = attempts to commit, 25b = incites another to commit, 25c = assists another to commit.';
+COMMENT ON COLUMN incident_role.associated_prisoners_number IS 'NOMIS offender number of the other prisoner involved, where the role code requires one.';
+COMMENT ON COLUMN incident_role.associated_prisoners_name IS 'Name of the other prisoner involved, held where they are not in the current establishment and cannot be looked up.';
+
+COMMENT ON TABLE incident_statement IS 'The reporting officer''s free text account of the incident, for a draft adjudication. One row per draft.';
+COMMENT ON COLUMN incident_statement.statement IS 'Free text description of the incident, up to 4000 characters.';
+COMMENT ON COLUMN incident_statement.completed IS 'True once the reporter has marked the statement as finished.';
+
+COMMENT ON TABLE offence IS 'The offence selected for a draft adjudication. In practice there is one row per draft; multiple offences are raised as separate charges.';
+COMMENT ON COLUMN offence.offence_code IS 'Internal DPS offence code (an integer, not the Prison Rules paragraph). Resolved in application code by OffenceCodeLookupService against the OffenceCodes enum - there is no reference table in this database. See the reference-data export for the full code list.';
+COMMENT ON COLUMN offence.victim_prisoners_number IS 'NOMIS offender number of the prisoner victim, for offences that have one.';
+COMMENT ON COLUMN offence.victim_staff_username IS 'DPS username of the staff victim, for offences that have one.';
+COMMENT ON COLUMN offence.victim_other_persons_name IS 'Name of a victim who is neither a prisoner nor staff (for example a visitor).';
+COMMENT ON COLUMN offence.draft_adjudication_fk_id IS 'Foreign key to draft_adjudications.';
+
+COMMENT ON TABLE draft_protected_characteristics IS 'Protected characteristics of the victim recorded as motivating the offence, on a draft adjudication. Copied to protected_characteristics on submission.';
+COMMENT ON COLUMN draft_protected_characteristics.characteristic IS 'One of AGE, DISABILITY, GENDER_REASSIGN, MARRIAGE_AND_CP, PREGNANCY_AND_MAT, RACE, RELIGION, SEX, SEX_ORIENTATION.';
+COMMENT ON COLUMN draft_protected_characteristics.offence_fk_id IS 'Foreign key to offence.';
+
+COMMENT ON TABLE damages IS 'Damage to prison property recorded on a draft adjudication. Copied to reported_damages on submission.';
+COMMENT ON COLUMN damages.code IS 'Type of damage. One of ELECTRICAL_REPAIR, PLUMBING_REPAIR, FURNITURE_OR_FABRIC_REPAIR, LOCK_REPAIR, REDECORATION, CLEANING, REPLACE_AN_ITEM.';
+COMMENT ON COLUMN damages.details IS 'Free text description of the damage.';
+COMMENT ON COLUMN damages.reporter IS 'DPS username of the officer who recorded this entry.';
+COMMENT ON COLUMN damages.draft_adjudication_fk_id IS 'Foreign key to draft_adjudications.';
+
+COMMENT ON TABLE evidence IS 'Evidence recorded on a draft adjudication. Copied to reported_evidence on submission.';
+COMMENT ON COLUMN evidence.code IS 'Type of evidence. One of PHOTO, BODY_WORN_CAMERA, CCTV, BAGGED_AND_TAGGED, OTHER.';
+COMMENT ON COLUMN evidence.identifier IS 'Reference number for the evidence, such as a body worn camera or seal number.';
+COMMENT ON COLUMN evidence.details IS 'Free text description of the evidence.';
+COMMENT ON COLUMN evidence.reporter IS 'DPS username of the officer who recorded this entry.';
+COMMENT ON COLUMN evidence.draft_adjudication_fk_id IS 'Foreign key to draft_adjudications.';
+
+COMMENT ON TABLE witness IS 'Witnesses recorded on a draft adjudication. Copied to reported_witness on submission.';
+COMMENT ON COLUMN witness.code IS 'Type of witness. One of OFFICER, STAFF, OTHER_PERSON, VICTIM, PRISONER.';
+COMMENT ON COLUMN witness.first_name IS 'Witness first name.';
+COMMENT ON COLUMN witness.last_name IS 'Witness last name.';
+COMMENT ON COLUMN witness.username IS 'DPS username of the witness where they are a member of staff.';
+COMMENT ON COLUMN witness.reporter IS 'DPS username of the officer who recorded this entry.';
+COMMENT ON COLUMN witness.draft_adjudication_fk_id IS 'Foreign key to draft_adjudications.';
+
+------------------------------------------------------------------------------------------------
+-- Reported (submitted) side - the main analytical tables
+------------------------------------------------------------------------------------------------
+
+COMMENT ON TABLE reported_adjudications IS 'A submitted adjudication charge - the root record for everything that follows (hearings, outcomes and punishments). One row per charge, not per incident: an incident involving several prisoners, or several offences, produces several rows. Includes records migrated from NOMIS as well as those raised in DPS.';
+COMMENT ON COLUMN reported_adjudications.charge_number IS 'Business key for the charge, unique across the service. Format is <agency><6 digit sequence> for DPS-raised charges (for example MDI001234); migrated NOMIS charges use the NOMIS charge number, suffixed -<n> where one NOMIS incident split into several DPS charges.';
+COMMENT ON COLUMN reported_adjudications.prisoner_number IS 'NOMIS offender number (noms id) of the prisoner charged.';
+COMMENT ON COLUMN reported_adjudications.offender_booking_id IS 'NOMIS OFFENDER_BOOK_ID for the booking the charge belongs to. Use this to join to NOMIS sentence and sanction data.';
+COMMENT ON COLUMN reported_adjudications.gender IS 'Prisoner gender, used to select the correct wording of offence paragraphs. One of MALE, FEMALE.';
+COMMENT ON COLUMN reported_adjudications.status IS 'Current state of the charge. One of AWAITING_REVIEW, RETURNED, REJECTED, ACCEPTED (deprecated), UNSCHEDULED, SCHEDULED, ADJOURNED, REFER_POLICE, REFER_INAD, REFER_GOV, PROSECUTION, DISMISSED, NOT_PROCEED, CHARGE_PROVED, QUASHED, INVALID_OUTCOME, INVALID_SUSPENDED, INVALID_ADA. Derived from the latest outcome by ReportedAdjudication.calculateStatus(). The three INVALID_* values flag data inconsistencies inherited from the NOMIS migration rather than real states.';
+COMMENT ON COLUMN reported_adjudications.status_reason IS 'Reason code recorded when the reviewer rejected or returned the report.';
+COMMENT ON COLUMN reported_adjudications.status_details IS 'Free text the reviewer gave alongside status_reason.';
+COMMENT ON COLUMN reported_adjudications.status_before_migration IS 'Status the charge held in NOMIS before migration. Populated on migrated records only.';
+COMMENT ON COLUMN reported_adjudications.originating_agency_id IS 'Agency (prison) code where the incident was reported. Together with override_agency_id this controls which caseload may see and action the record.';
+COMMENT ON COLUMN reported_adjudications.override_agency_id IS 'Agency code the prisoner transferred to after the charge was raised, set by TransferService from prisoner movement events. Null when there has been no transfer.';
+COMMENT ON COLUMN reported_adjudications.last_modified_agency_id IS 'Agency code of the establishment that last changed the record.';
+COMMENT ON COLUMN reported_adjudications.date_time_of_incident IS 'When the incident occurred.';
+COMMENT ON COLUMN reported_adjudications.date_time_of_discovery IS 'When the incident was discovered. Equal to the incident date unless it was found later; the 48 hour notice clock runs from here.';
+COMMENT ON COLUMN reported_adjudications.handover_deadline IS 'Deadline for issuing the notice of report to the prisoner, calculated as 48 hours after discovery.';
+COMMENT ON COLUMN reported_adjudications.location_id IS 'Legacy NOMIS internal location id where the incident occurred. Superseded by location_uuid.';
+COMMENT ON COLUMN reported_adjudications.location_uuid IS 'Location identifier in the locations-inside-prison service. This is the current location reference.';
+COMMENT ON COLUMN reported_adjudications.is_youth_offender IS 'True when the YOI rule set applies rather than the adult rule set.';
+COMMENT ON COLUMN reported_adjudications.incident_role_code IS 'Paragraph 25 role code. Null means the prisoner committed the offence alone. 25a = attempts to commit, 25b = incites another to commit, 25c = assists another to commit.';
+COMMENT ON COLUMN reported_adjudications.incident_role_associated_prisoners_number IS 'NOMIS offender number of the other prisoner involved, where the role code requires one.';
+COMMENT ON COLUMN reported_adjudications.incident_role_associated_prisoners_name IS 'Name of the other prisoner involved, held where they cannot be looked up.';
+COMMENT ON COLUMN reported_adjudications.statement IS 'The reporting officer''s free text account of the incident.';
+COMMENT ON COLUMN reported_adjudications.review_user_id IS 'DPS username of the reviewer who accepted, rejected or returned the report.';
+COMMENT ON COLUMN reported_adjudications.issuing_officer IS 'DPS username of the officer who most recently issued the notice of report (DIS1/2) to the prisoner.';
+COMMENT ON COLUMN reported_adjudications.date_time_of_issue IS 'When the notice of report was most recently issued. Full history is in dis_issue_history.';
+COMMENT ON COLUMN reported_adjudications.date_time_of_first_hearing IS 'Denormalised date of the earliest hearing, maintained for reporting and sorting.';
+COMMENT ON COLUMN reported_adjudications.date_time_resubmitted IS 'When a returned report was resubmitted for review. Where set, this is treated as the report''s created date in the API.';
+COMMENT ON COLUMN reported_adjudications.agency_incident_id IS 'NOMIS AGENCY_INCIDENT_ID the charge came from. Populated on migrated records and on records synchronised back to NOMIS.';
+COMMENT ON COLUMN reported_adjudications.migrated IS 'True when the record was migrated from NOMIS rather than raised in DPS.';
+COMMENT ON COLUMN reported_adjudications.migrated_inactive_prisoner IS 'True when the record was migrated for a prisoner who was no longer active. These records are excluded from the INVALID_* status checks because their data cannot be corrected.';
+COMMENT ON COLUMN reported_adjudications.migrated_split_record IS 'True when a single NOMIS charge was split into multiple DPS charges during migration.';
+COMMENT ON COLUMN reported_adjudications.created_on_behalf_of_officer IS 'Name of the officer the report was created on behalf of, when someone else entered it for them.';
+COMMENT ON COLUMN reported_adjudications.created_on_behalf_of_reason IS 'Reason the report was created on behalf of another officer.';
+
+COMMENT ON TABLE reported_offence IS 'The offence charged on a submitted adjudication. One row per reported adjudication.';
+COMMENT ON COLUMN reported_offence.offence_code IS 'Internal DPS offence code (an integer, not the Prison Rules paragraph). Resolved in application code by OffenceCodeLookupService against the OffenceCodes enum - there is no reference table in this database. Migrated NOMIS charges that could not be mapped use the MIGRATED_OFFENCE code and carry the original text in nomis_offence_code / nomis_offence_description. See the reference-data export for the full code list.';
+COMMENT ON COLUMN reported_offence.actual_offence_code IS 'The offence code originally chosen, retained when the stored offence_code was subsequently adjusted.';
+COMMENT ON COLUMN reported_offence.nomis_offence_code IS 'NOMIS OIC offence code, for example 51:1A. Populated on migrated records.';
+COMMENT ON COLUMN reported_offence.nomis_offence_description IS 'NOMIS offence description text. Populated on migrated records, and used in place of the DPS paragraph description where the offence could not be mapped.';
+COMMENT ON COLUMN reported_offence.victim_prisoners_number IS 'NOMIS offender number of the prisoner victim, for offences that have one.';
+COMMENT ON COLUMN reported_offence.victim_staff_username IS 'DPS username of the staff victim, for offences that have one.';
+COMMENT ON COLUMN reported_offence.victim_other_persons_name IS 'Name of a victim who is neither a prisoner nor staff (for example a visitor).';
+COMMENT ON COLUMN reported_offence.migrated IS 'True when the offence row was created by the NOMIS migration.';
+COMMENT ON COLUMN reported_offence.reported_adjudication_fk_id IS 'Foreign key to reported_adjudications.';
+
+COMMENT ON TABLE protected_characteristics IS 'Protected characteristics of the victim recorded as motivating the offence, on a submitted adjudication.';
+COMMENT ON COLUMN protected_characteristics.characteristic IS 'One of AGE, DISABILITY, GENDER_REASSIGN, MARRIAGE_AND_CP, PREGNANCY_AND_MAT, RACE, RELIGION, SEX, SEX_ORIENTATION.';
+COMMENT ON COLUMN protected_characteristics.reported_offence_fk_id IS 'Foreign key to reported_offence.';
+
+COMMENT ON TABLE reported_damages IS 'Damage to prison property recorded on a submitted adjudication.';
+COMMENT ON COLUMN reported_damages.code IS 'Type of damage. One of ELECTRICAL_REPAIR, PLUMBING_REPAIR, FURNITURE_OR_FABRIC_REPAIR, LOCK_REPAIR, REDECORATION, CLEANING, REPLACE_AN_ITEM.';
+COMMENT ON COLUMN reported_damages.details IS 'Free text description of the damage.';
+COMMENT ON COLUMN reported_damages.repair_cost IS 'Cost of repair in pounds, where recorded. Separate from the DAMAGES_OWED punishment, which is the amount the prisoner was ordered to pay.';
+COMMENT ON COLUMN reported_damages.reporter IS 'DPS username of the officer who recorded this entry.';
+COMMENT ON COLUMN reported_damages.reported_adjudication_fk_id IS 'Foreign key to reported_adjudications.';
+
+COMMENT ON TABLE reported_evidence IS 'Evidence recorded on a submitted adjudication.';
+COMMENT ON COLUMN reported_evidence.code IS 'Type of evidence. One of PHOTO, BODY_WORN_CAMERA, CCTV, BAGGED_AND_TAGGED, OTHER.';
+COMMENT ON COLUMN reported_evidence.identifier IS 'Reference number for the evidence, such as a body worn camera or seal number.';
+COMMENT ON COLUMN reported_evidence.details IS 'Free text description of the evidence.';
+COMMENT ON COLUMN reported_evidence.date_added IS 'When the evidence was added to the report, where it was added after submission.';
+COMMENT ON COLUMN reported_evidence.reporter IS 'DPS username of the officer who recorded this entry.';
+COMMENT ON COLUMN reported_evidence.reported_adjudication_fk_id IS 'Foreign key to reported_adjudications.';
+
+COMMENT ON TABLE reported_witness IS 'Witnesses recorded on a submitted adjudication.';
+COMMENT ON COLUMN reported_witness.code IS 'Type of witness. One of OFFICER, STAFF, OTHER_PERSON, VICTIM, PRISONER.';
+COMMENT ON COLUMN reported_witness.first_name IS 'Witness first name.';
+COMMENT ON COLUMN reported_witness.last_name IS 'Witness last name.';
+COMMENT ON COLUMN reported_witness.username IS 'DPS username of the witness where they are a member of staff.';
+COMMENT ON COLUMN reported_witness.comment IS 'Free text note about the witness or their evidence.';
+COMMENT ON COLUMN reported_witness.date_added IS 'When the witness was added to the report, where they were added after submission.';
+COMMENT ON COLUMN reported_witness.reporter IS 'DPS username of the officer who recorded this entry.';
+COMMENT ON COLUMN reported_witness.reported_adjudication_fk_id IS 'Foreign key to reported_adjudications.';
+
+COMMENT ON TABLE dis_issue_history IS 'Full history of issuing the notice of being placed on report (DIS1/2) to the prisoner. The most recent issue is also denormalised onto reported_adjudications.';
+COMMENT ON COLUMN dis_issue_history.issuing_officer IS 'DPS username of the officer who issued the form.';
+COMMENT ON COLUMN dis_issue_history.date_time_of_issue IS 'When the form was issued to the prisoner.';
+COMMENT ON COLUMN dis_issue_history.reported_adjudication_fk_id IS 'Foreign key to reported_adjudications.';
+
+------------------------------------------------------------------------------------------------
+-- Hearings and outcomes
+------------------------------------------------------------------------------------------------
+
+COMMENT ON TABLE hearing IS 'A scheduled or held adjudication hearing. A charge can have several hearings, for example where the first is adjourned. The ordered case history shown in the UI is assembled from this table and outcome by ReportedAdjudicationService.createOutcomeHistory().';
+COMMENT ON COLUMN hearing.date_time_of_hearing IS 'When the hearing is scheduled for, or was held.';
+COMMENT ON COLUMN hearing.oic_hearing_type IS 'Who hears the case, and under which rule set. One of GOV_ADULT, GOV_YOI, INAD_ADULT, INAD_YOI, GOV. GOV = governor, INAD = independent adjudicator.';
+COMMENT ON COLUMN hearing.agency_id IS 'Agency (prison) code where the hearing takes place. May differ from the charge''s originating agency after a transfer.';
+COMMENT ON COLUMN hearing.charge_number IS 'Charge number of the parent adjudication, denormalised for lookup.';
+COMMENT ON COLUMN hearing.location_id IS 'Legacy NOMIS internal location id of the hearing room. Superseded by location_uuid.';
+COMMENT ON COLUMN hearing.location_uuid IS 'Location identifier in the locations-inside-prison service. This is the current location reference.';
+COMMENT ON COLUMN hearing.oic_hearing_id IS 'NOMIS OIC_HEARING_ID. Populated for migrated hearings and for hearings synchronised back to NOMIS.';
+COMMENT ON COLUMN hearing.representative IS 'Name of the prisoner''s representative at the hearing, where they had one.';
+COMMENT ON COLUMN hearing.outcome_id IS 'Foreign key to hearing_outcome. Null while the hearing is scheduled but not yet held.';
+COMMENT ON COLUMN hearing.hearing_pre_migrate_id IS 'Legacy column from the NOMIS migration. The table it referenced was dropped in V91 and it is no longer populated.';
+COMMENT ON COLUMN hearing.reported_adjudication_fk_id IS 'Foreign key to reported_adjudications.';
+
+COMMENT ON TABLE hearing_outcome IS 'What happened at a hearing. One row per hearing that has been held.';
+COMMENT ON COLUMN hearing_outcome.code IS 'What the adjudicator did. One of COMPLETE (a finding was reached - see the linked outcome row for what it was), ADJOURN, REFER_POLICE, REFER_INAD, REFER_GOV, NOMIS (outcome was entered in NOMIS rather than DPS).';
+COMMENT ON COLUMN hearing_outcome.adjudicator IS 'Name or username of the governor or independent adjudicator who heard the case.';
+COMMENT ON COLUMN hearing_outcome.adjourn_reason IS 'Why the hearing was adjourned. One of LEGAL_ADVICE, LEGAL_REPRESENTATION, RO_ATTEND, HELP, UNFIT, WITNESS, WITNESS_SUPPORT, MCKENZIE, EVIDENCE, INVESTIGATION, OTHER. Null unless code is ADJOURN.';
+COMMENT ON COLUMN hearing_outcome.plea IS 'The prisoner''s plea. One of GUILTY, NOT_GUILTY, ABSTAIN, UNFIT, NOT_ASKED.';
+COMMENT ON COLUMN hearing_outcome.details IS 'Free text notes recorded against the hearing outcome.';
+COMMENT ON COLUMN hearing_outcome.nomis_outcome IS 'True when the outcome was recorded in NOMIS rather than DPS, so DPS holds only a placeholder.';
+COMMENT ON COLUMN hearing_outcome.migrated IS 'True when the row was created by the NOMIS migration.';
+COMMENT ON COLUMN hearing_outcome.hearing_outcome_pre_migrate_id IS 'Legacy column from the NOMIS migration. The table it referenced was dropped in V91 and it is no longer populated.';
+
+COMMENT ON TABLE outcome IS 'A finding or decision on a charge. Some outcomes follow a hearing, others are recorded without one (for example referring to the police before any hearing). Ordering is by actual_created_date where set, otherwise create_datetime.';
+COMMENT ON COLUMN outcome.code IS 'The finding or decision. One of REFER_POLICE, REFER_INAD, REFER_GOV, NOT_PROCEED, DISMISSED, PROSECUTION, SCHEDULE_HEARING, CHARGE_PROVED, QUASHED. CHARGE_PROVED is the outcome that allows punishments to be awarded; QUASHED revokes them.';
+COMMENT ON COLUMN outcome.details IS 'Free text supporting the outcome.';
+COMMENT ON COLUMN outcome.not_proceed_reason IS 'Why the charge was not proceeded with. One of ANOTHER_WAY, RELEASED, WITNESS_NOT_ATTEND, UNFIT, FLAWED, EXPIRED_NOTICE, EXPIRED_HEARING, NOT_FAIR, OTHER. Null unless code is NOT_PROCEED.';
+COMMENT ON COLUMN outcome.quashed_reason IS 'Why the charge was quashed. One of FLAWED_CASE, JUDICIAL_REVIEW, APPEAL_UPHELD, OTHER. Null unless code is QUASHED.';
+COMMENT ON COLUMN outcome.refer_gov_reason IS 'Why the case was referred to the governor. One of REVIEW_FOR_REFER_POLICE, GOV_INQUIRY, OTHER. Null unless code is REFER_GOV.';
+COMMENT ON COLUMN outcome.oic_hearing_id IS 'NOMIS OIC_HEARING_ID the outcome relates to, where the outcome came from or was synchronised to NOMIS.';
+COMMENT ON COLUMN outcome.deleted IS 'Soft delete flag. Rows where this is true are excluded from the case history and from status calculation; queries must filter on "deleted is not true".';
+COMMENT ON COLUMN outcome.actual_created_date IS 'The real date the outcome was reached, as opposed to create_datetime which for migrated records is the date of the migration run. Use this for chronology.';
+COMMENT ON COLUMN outcome.migrated IS 'True when the row was created by the NOMIS migration.';
+COMMENT ON COLUMN outcome.reported_adjudication_fk_id IS 'Foreign key to reported_adjudications.';
+
+------------------------------------------------------------------------------------------------
+-- Punishments
+------------------------------------------------------------------------------------------------
+
+COMMENT ON TABLE punishment IS 'A punishment (NOMIS calls these awards or sanctions) given on a charge where the outcome was CHARGE_PROVED. The duration or amount is not held here but on the linked punishment_schedule rows. ADDITIONAL_DAYS and PROSPECTIVE_DAYS punishments are the added days that feed sentence calculation via the adjustments service.';
+COMMENT ON COLUMN punishment.type IS 'Type of punishment. One of PRIVILEGE (loss of privileges - see privilege_type), EARNINGS (stoppage of earnings - see stoppage_percentage), CONFINEMENT (cellular confinement), REMOVAL_ACTIVITY, EXCLUSION_WORK, EXTRA_WORK, REMOVAL_WING, ADDITIONAL_DAYS (added days awarded, ADA), PROSPECTIVE_DAYS (prospective added days, PADA - awarded where the prisoner is not yet sentenced), CAUTION, DAMAGES_OWED (money owed for damage - see amount), PAYBACK (payback punishment, measured in hours).';
+COMMENT ON COLUMN punishment.privilege_type IS 'Which privilege was lost. One of CANTEEN, FACILITIES, MONEY, TV, ASSOCIATION, GYM, OTHER. Null unless type is PRIVILEGE.';
+COMMENT ON COLUMN punishment.other_privilege IS 'Free text description of the privilege lost, when privilege_type is OTHER.';
+COMMENT ON COLUMN punishment.stoppage_percentage IS 'Percentage of earnings stopped. Null unless type is EARNINGS.';
+COMMENT ON COLUMN punishment.amount IS 'Amount of money owed, in pounds. Null unless type is DAMAGES_OWED.';
+COMMENT ON COLUMN punishment.suspended_until IS 'Date the punishment is suspended until. Non-null means the punishment is suspended and not currently in force. Mirrors the suspended_until on the latest punishment_schedule row.';
+COMMENT ON COLUMN punishment.activated_by_charge_number IS 'Charge number of the later adjudication that activated this suspended punishment. Null while the punishment remains suspended or was never suspended.';
+COMMENT ON COLUMN punishment.consecutive_to_charge_number IS 'Charge number this punishment runs consecutively to. Used for added days that follow on from an award on an earlier charge.';
+COMMENT ON COLUMN punishment.deleted IS 'Soft delete flag. Rows where this is true are excluded everywhere; queries must filter on "deleted is not true".';
+COMMENT ON COLUMN punishment.sanction_seq IS 'NOMIS OFFENDER_OIC_SANCTIONS.SANCTION_SEQ. With reported_adjudications.offender_booking_id this forms the composite key of the matching NOMIS sanction row.';
+COMMENT ON COLUMN punishment.nomis_status IS 'NOMIS sanction status (reference domain OIC_SANCT_ST) for records that came from or were synchronised to NOMIS. Values include IMMEDIATE, PROSPECTIVE, SUSPENDED, SUSP_PROSP, QUASHED, AWARD_RED, REDAPP, SUSPEN_RED, SUSPEN_EXT, AS_AWARDED.';
+COMMENT ON COLUMN punishment.actual_created_date IS 'The real date the punishment was awarded, as opposed to create_datetime which for migrated records is the date of the migration run. Use this for chronology.';
+COMMENT ON COLUMN punishment.payback_notes IS 'Free text description of the payback work required. Null unless type is PAYBACK.';
+COMMENT ON COLUMN punishment.rehab_completed IS 'Whether the attached rehabilitative activities were completed. Null where no rehabilitative activity applies or the outcome has not yet been recorded.';
+COMMENT ON COLUMN punishment.rehab_not_completed_outcome IS 'What was decided when rehabilitative activities were not completed. One of FULL_ACTIVATE, PARTIAL_ACTIVATE, EXT_SUSPEND, NO_ACTION.';
+COMMENT ON COLUMN punishment.punishment_pre_migrate_id IS 'Legacy column from the NOMIS migration. The table it referenced was dropped in V91 and it is no longer populated.';
+COMMENT ON COLUMN punishment.reported_adjudication_fk_id IS 'Foreign key to reported_adjudications.';
+
+COMMENT ON TABLE punishment_schedule IS 'The duration and dates of a punishment. A punishment gains a new schedule row each time it is amended, so this table is a history: take the row with the greatest create_datetime for a given punishment_fk_id to get the current position.';
+COMMENT ON COLUMN punishment_schedule.duration IS 'Length of the punishment, in the unit given by measurement. This is the added days count for ADDITIONAL_DAYS and PROSPECTIVE_DAYS punishments. Renamed from "days" in V115 when payback punishments introduced hours.';
+COMMENT ON COLUMN punishment_schedule.measurement IS 'Unit of duration. One of DAYS, HOURS. HOURS is used only by PAYBACK punishments.';
+COMMENT ON COLUMN punishment_schedule.start_date IS 'Date the punishment starts. Not set for added days, which take effect through a sentence adjustment rather than a date range.';
+COMMENT ON COLUMN punishment_schedule.end_date IS 'Date the punishment ends. Not set for added days.';
+COMMENT ON COLUMN punishment_schedule.suspended_until IS 'Date the punishment is suspended until. Non-null means the punishment was suspended as at this schedule row.';
+COMMENT ON COLUMN punishment_schedule.punishment_fk_id IS 'Foreign key to punishment.';
+
+COMMENT ON TABLE punishment_comments IS 'Free text notes recorded against the punishments on a charge, including the reason for any change made on appeal or correction.';
+COMMENT ON COLUMN punishment_comments.comment IS 'The note text.';
+COMMENT ON COLUMN punishment_comments.reason_for_change IS 'Why the punishments were changed. One of APPEAL, CORRECTION, OTHER, GOV_OR_DIRECTOR.';
+COMMENT ON COLUMN punishment_comments.nomis_created_by IS 'Username of the NOMIS user who created the comment, for migrated records. Takes precedence over create_user_id when displaying the author.';
+COMMENT ON COLUMN punishment_comments.actual_created_date IS 'The real date the comment was made, as opposed to create_datetime which for migrated records is the date of the migration run.';
+COMMENT ON COLUMN punishment_comments.reported_adjudication_fk_id IS 'Foreign key to reported_adjudications.';
+
+COMMENT ON TABLE rehabilitative_activity IS 'Rehabilitative activities attached to a suspended punishment as a condition of the suspension. Not available for added days, cautions, damages owed or payback punishments.';
+COMMENT ON COLUMN rehabilitative_activity.details IS 'Description of the activity the prisoner must complete.';
+COMMENT ON COLUMN rehabilitative_activity.monitor IS 'Name of the person responsible for monitoring the activity.';
+COMMENT ON COLUMN rehabilitative_activity.end_date IS 'Date the activity must be completed by.';
+COMMENT ON COLUMN rehabilitative_activity.total_sessions IS 'Number of sessions the prisoner must attend.';
+COMMENT ON COLUMN rehabilitative_activity.completed IS 'Whether this individual activity was completed. The overall decision is held on punishment.rehab_completed.';
+COMMENT ON COLUMN rehabilitative_activity.punishment_fk_id IS 'Foreign key to punishment.';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ExportReferenceData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/ExportReferenceData.kt
@@ -1,0 +1,110 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Characteristic
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.DamageCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.EvidenceCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Gender
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeAdjournReason
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomeCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.HearingOutcomePlea
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.Measurement
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.NotCompletedOutcome
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.NotProceedReason
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OicHearingType
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.OutcomeCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PrivilegeType
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.PunishmentType
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.QuashedReason
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReasonForChange
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReferGovReason
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.ReportedAdjudicationStatus
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.entities.WitnessCode
+import uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.services.OffenceCodes
+import java.io.File
+
+/**
+ * Writes reference-data.csv, the companion to the SchemaSpy report and data-dictionary.csv.
+ *
+ * Every code in this schema is a JPA string enum or an integer resolved in Kotlin - there are no
+ * reference tables in the database - so a schema report alone leaves an analyst unable to decode
+ * columns such as reported_offence.offence_code or punishment.type. This exports those lookups.
+ *
+ * Excluded from normal test runs; run with `./gradlew -Pinit-db=true test` (see build.gradle.kts).
+ */
+class ExportReferenceData {
+
+  @Test
+  fun `exports reference data`() {
+    val rows = mutableListOf<Row>()
+
+    rows += enumRows("reported_adjudications.status", ReportedAdjudicationStatus.entries)
+    rows += enumRows("reported_adjudications.gender", Gender.entries)
+    rows += Row("reported_adjudications.incident_role_code", "25a", "Attempts to commit any of the foregoing offences")
+    rows += Row("reported_adjudications.incident_role_code", "25b", "Incites another prisoner to commit any of the foregoing offences")
+    rows += Row("reported_adjudications.incident_role_code", "25c", "Assists another prisoner to commit, or to attempt to commit, any of the foregoing offences")
+
+    rows += enumRows("outcome.code", OutcomeCode.entries)
+    rows += enumRows("outcome.not_proceed_reason", NotProceedReason.entries)
+    rows += enumRows("outcome.quashed_reason", QuashedReason.entries)
+    rows += enumRows("outcome.refer_gov_reason", ReferGovReason.entries)
+
+    rows += enumRows("hearing.oic_hearing_type", OicHearingType.entries)
+    rows += enumRows("hearing_outcome.code", HearingOutcomeCode.entries)
+    rows += enumRows("hearing_outcome.adjourn_reason", HearingOutcomeAdjournReason.entries)
+    rows += enumRows("hearing_outcome.plea", HearingOutcomePlea.entries)
+
+    rows += enumRows("punishment.type", PunishmentType.entries)
+    rows += enumRows("punishment.privilege_type", PrivilegeType.entries)
+    rows += enumRows("punishment.rehab_not_completed_outcome", NotCompletedOutcome.entries)
+    rows += enumRows("punishment_schedule.measurement", Measurement.entries)
+    rows += enumRows("punishment_comments.reason_for_change", ReasonForChange.entries)
+
+    rows += enumRows("damages.code / reported_damages.code", DamageCode.entries)
+    rows += enumRows("evidence.code / reported_evidence.code", EvidenceCode.entries)
+    rows += enumRows("witness.code / reported_witness.code", WitnessCode.entries)
+    rows += enumRows(
+      "protected_characteristics.characteristic / draft_protected_characteristics.characteristic",
+      Characteristic.entries,
+    )
+
+    rows += offenceCodeRows()
+
+    val output = File(System.getProperty("referenceDataOutput") ?: "reference-data.csv")
+    output.bufferedWriter().use { writer ->
+      writer.write("column_ref,code,description,notes\n")
+      rows.forEach { writer.write("${it.toCsv()}\n") }
+    }
+    println("Wrote ${rows.size} reference data rows to ${output.absolutePath}")
+  }
+
+  /**
+   * offence.offence_code and reported_offence.offence_code hold the integers in
+   * OffenceCodes.uniqueOffenceCodes, so one enum entry expands to several stored values.
+   */
+  private fun offenceCodeRows(): List<Row> = OffenceCodes.entries.flatMap { offence ->
+    offence.uniqueOffenceCodes.map { code ->
+      Row(
+        columnRef = "offence.offence_code / reported_offence.offence_code",
+        code = code.toString(),
+        description = offence.paragraphDescription.getParagraphDescription(Gender.MALE),
+        notes = "name=${offence.name}; nomisCode=${offence.nomisCode}; paragraph=${offence.paragraph}; " +
+          "withOthersNomisCode=${offence.getNomisCodeWithOthers()}; " +
+          "applicableVersions=${offence.applicableVersions.joinToString("|")}",
+      )
+    }
+  }
+
+  private fun <T : Enum<T>> enumRows(columnRef: String, values: List<T>) = values.map { Row(columnRef, it.name, "") }
+
+  private data class Row(
+    val columnRef: String,
+    val code: String,
+    val description: String,
+    val notes: String = "",
+  ) {
+    fun toCsv() = listOf(columnRef, code, description, notes).joinToString(",") { escape(it) }
+
+    private fun escape(value: String) = "\"${value.replace("\"", "\"\"")}\""
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/InitialiseDatabase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageadjudicationsapi/integration/InitialiseDatabase.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration
+
+import org.junit.jupiter.api.Test
+
+/**
+ * Builds the schema so the SchemaSpy report can be generated against it.
+ *
+ * Excluded from normal test runs; run with `./gradlew -Pinit-db=true test` (see build.gradle.kts).
+ * Starting the application context is enough - Flyway migrates on startup.
+ */
+class InitialiseDatabase : IntegrationTestBase() {
+
+  @Test
+  fun `initialises database`() {
+    println("Database has been initialised by IntegrationTestBase")
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -64,6 +64,6 @@ hmpps:
         path: /sar/sar-api-response.json
       expected-render-result:
         path: /sar/sar-generated-report.html
-      expected-flyway-schema-version: 129
+      expected-flyway-schema-version: 130
       expected-jpa-entity-schema:
         path: /sar/entity-schema.json


### PR DESCRIPTION
## Why

The data team asked for a data dictionary for the adjudications tables — they have data users asking
for one, and want to load it into the MOJ Data Catalogue via Glue. CSIP already does this with
SchemaSpy, which is the shape they liked.

## What

Table and column descriptions are added as `COMMENT ON` statements in `V130__schema_comments.sql`,
so the database itself is the source of truth and SchemaSpy, the CSV export and any Glue crawl all
agree. **Every business column is covered** — verified against `pg_description`.

On every push to `main` the new `schema-spy` job builds the schema with Flyway and publishes three
artefacts to `gh-pages` under `schema-spy-report/`:

| Artefact | Contents |
|---|---|
| SchemaSpy report | Browsable ER diagrams and table docs |
| `data-dictionary.csv` | Flat table/column export — description, type, nullability, PK, FK |
| `reference-data.csv` | Enum and offence code lookups |

That third file is the one worth explaining. Nothing in this schema is a reference table:
`reported_offence.offence_code` is an integer resolved by `OffenceCodeLookupService` against the
`OffenceCodes` enum, and every other code column is an `@Enumerated(EnumType.STRING)` value. A schema
report alone therefore leaves an analyst unable to decode them, so `ExportReferenceData` walks the
enums and expands the offence codes into a CSV alongside.

## Changes

- `V130__schema_comments.sql` — descriptions for all 23 tables and every business column
- `docker-compose-schema-spy.yml` — Postgres only, matching `application-test.yml`
- `InitialiseDatabase` / `ExportReferenceData` — gated behind `-Pinit-db=true`, excluded from `check`
- `scripts/generate-data-dictionary.sh` — CSV export, works with or without a local `psql`
- `.github/workflows/schema-spy.yml` + a `schema-spy` job in `pipeline.yml`, gated on `main`
- SAR `expected-flyway-schema-version` bumped 129 → 130
- README section on regenerating locally

## Verification

- Flyway `clean migrate` from scratch to V130 ✅
- Zero business columns without a description in `pg_description` ✅
- SchemaSpy renders the table and column comments; 23 tables + `flyway_schema_history` ✅
- `data-dictionary.csv` — 291 columns ✅
- `reference-data.csv` — 279 rows; offence code `100124` resolves to `51:1A (24)` / paragraph `1(a)` /
  version 2, and the v1 `ADULT_51_1A` codes are present ✅
- `compileTestKotlin` and `ktlintCheck` pass; both new test classes are excluded from a normal `test` run ✅

## One manual step after merge

GitHub Pages is not yet enabled on this repo. The first `main` build creates the `gh-pages` branch;
Pages then needs pointing at it (branch `gh-pages`, path `/`) to serve
`https://ministryofjustice.github.io/hmpps-manage-adjudications-api/schema-spy-report/`.