### PR TITLE
IR-1797 Fix schema-spy workflow permissions for gh-pages publish

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -65,6 +65,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs:
       - gradle_verify
+    # top-level permissions grant contents: read; the reusable workflow needs write to publish to gh-pages
+    permissions:
+      contents: write
     uses: ./.github/workflows/schema-spy.yml
     secrets: inherit
   build:


### PR DESCRIPTION
## Why

The `schema-spy` job merged in #1025 fails on `main` at workflow-validation time:

> The nested job 'schema-spy' is requesting 'contents: write', but is only allowed 'contents: read'.

`pipeline.yml` sets top-level `permissions: contents: read`. A called reusable workflow (`schema-spy.yml`) cannot be granted more than the caller allows, and it needs `contents: write` to publish the SchemaSpy report + CSVs to the `gh-pages` branch.

## What

Grant `contents: write` on the `schema-spy` calling job only, leaving the repo-wide default at `contents: read`.

## Note

This blocks the data-dictionary publish but not deploys — `build`/`deploy_*` run independently of `schema-spy`.