### PR TITLE
IR-1797 Add LocalStack to schema-spy so the app context can boot

### DIFF
--- a/.github/workflows/schema-spy.yml
+++ b/.github/workflows/schema-spy.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Initialise database and export reference data
         shell: bash
         run: |
-          docker compose -f ${{ inputs.docker_compose_file }} up -d
+          docker compose -f ${{ inputs.docker_compose_file }} up -d --wait
           export JAVA_OPTS="${{ inputs.java_options }}"
           ./gradlew -Pinit-db=true -PreferenceDataOutput="${PWD}/reference-data.csv" test \
             --tests uk.gov.justice.digital.hmpps.hmppsmanageadjudicationsapi.integration.InitialiseDatabase \

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ can add to or replace comments at any time.
 To regenerate locally:
 
 ```bash
-docker compose -f docker-compose-schema-spy.yml up -d
+docker compose -f docker-compose-schema-spy.yml up -d --wait
 ./gradlew -Pinit-db=true test --tests '*InitialiseDatabase' --tests '*ExportReferenceData'
 docker run --rm --network host -v /tmp/schemaspy:/output schemaspy/schemaspy:6.2.4 \
   -t pgsql -host localhost -port 5432 -db adjudications -s public \

--- a/docker-compose-schema-spy.yml
+++ b/docker-compose-schema-spy.yml
@@ -11,6 +11,29 @@ services:
       - POSTGRES_DB=adjudications
       - POSTGRES_USER=adjudications
       - POSTGRES_PASSWORD=adjudications
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U adjudications -d adjudications"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  # The InitialiseDatabase test boots the full Spring context, which wires HmppsQueueService
+  # (SNS/SQS). Without LocalStack the context fails to start and Flyway never runs, so SchemaSpy
+  # has no schema to read. This mirrors the LocalStack service container the normal CI provides.
+  localstack:
+    image: localstack/localstack:community-archive
+    networks:
+      - hmpps
+    container_name: localstack-schema-spy
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=sqs,sns
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:4566/_localstack/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
 
 networks:
   hmpps:


### PR DESCRIPTION
## Why

The `schema-spy` job fails at the *Initialise database* step on `main`:

```
Failed to instantiate HmppsQueueService: Unable to execute HTTP request:
Connection refused: localhost/127.0.0.1:4566
```

`InitialiseDatabase` extends `IntegrationTestBase`, which boots the full Spring context. That wires `HmppsQueueService` (SNS/SQS), which the plain integration base expects at the static `localhost:4566` from `application-test.yml`. The schema-spy compose only started Postgres, so the context failed to load and Flyway never ran — leaving SchemaSpy with no schema. (Normal CI provides LocalStack as a service container, which is why the wider test suite is unaffected.)

## What

- Add a LocalStack container (`sqs,sns`) to `docker-compose-schema-spy.yml`, plus healthchecks on both containers.
- `docker compose up -d --wait` in the workflow so the gradle step doesn't start until both are healthy.
- README local-regen command updated to `--wait` to match.

The hmpps-sqs starter auto-provisions the queues/topic on LocalStack at startup, so no seeding is needed.

## Verified locally

`docker compose -f docker-compose-schema-spy.yml up -d --wait` → both healthy → `./gradlew -Pinit-db=true … InitialiseDatabase ExportReferenceData` → **BUILD SUCCESSFUL**, 23 tables migrated (incl. V130), `reference-data.csv` = 279 rows.